### PR TITLE
feat: add consecutive centroid stability analysis to speaker stability pipeline

### DIFF
--- a/src/prosodic_feature_extraction/features/incremental_embeddings.py
+++ b/src/prosodic_feature_extraction/features/incremental_embeddings.py
@@ -38,14 +38,34 @@ def select_k(
     return selected
 
 
+def _cosine(a: torch.Tensor, b: torch.Tensor) -> float:
+    return float(torch.clamp(F.cosine_similarity(a, b, dim=0), -1.0, 1.0))
+
+
 def cosine_to_full(
     centroids: Dict[int, torch.Tensor],
     full: torch.Tensor,
 ) -> Dict[int, float]:
-    out: Dict[int, float] = {}
-    for k, emb in centroids.items():
-        out[int(k)] = F.cosine_similarity(emb, full, dim=0).item()
-    return out
+    return {int(k): _cosine(emb, full) for k, emb in centroids.items()}
+
+
+def cosine_consecutive(centroids: List[torch.Tensor]) -> Dict[int, float]:
+    """Cosine similarity between centroid_k and centroid_{k-1} for k >= 2."""
+    return {
+        k: _cosine(centroids[k - 1], centroids[k - 2])
+        for k in range(2, len(centroids) + 1)
+    }
+
+
+def stability_point_consecutive(
+    cosines_consec: Dict[int, float],
+    threshold: float = 0.999,
+) -> int | None:
+    """First k >= 2 where s_k'' >= threshold."""
+    for k in sorted(cosines_consec.keys()):
+        if cosines_consec[k] >= threshold:
+            return k
+    return None
 
 
 def stability_point(

--- a/src/prosodic_feature_extraction/metrics/similarity.py
+++ b/src/prosodic_feature_extraction/metrics/similarity.py
@@ -5,7 +5,7 @@ import torch.nn.functional as F
 
 
 def cosine(a: torch.Tensor, b: torch.Tensor) -> float:
-    return F.cosine_similarity(a, b, dim=0).item()
+    return float(torch.clamp(F.cosine_similarity(a, b, dim=0), -1.0, 1.0))
 
 
 def frame_level_similarity_naive(a: torch.Tensor, b: torch.Tensor) -> float:

--- a/src/prosodic_feature_extraction/models/speaker_stability.py
+++ b/src/prosodic_feature_extraction/models/speaker_stability.py
@@ -24,6 +24,17 @@ DatasetName = Literal["l2arctic", "saa"]
 EmbeddingType = Literal["mean_std", "xvector"]
 
 
+class KFloatMap(BaseModel):
+    """Mapping from utterance count k (integer) to a float metric value."""
+    values: Dict[int, float] = Field(default_factory=dict)
+
+
+class EmbeddingsByK(TensorModel):
+    """Per-k centroid embeddings plus the full-corpus centroid."""
+    by_k: Dict[int, torch.Tensor]
+    full: torch.Tensor
+
+
 class RepresentationConfig(BaseModel):
     name: str
     model_name: str
@@ -55,14 +66,18 @@ class SpeakerStabilityPayload(TensorModel):
     ordered_utterance_ids: List[str]
     num_utterances: int
     total_seconds: float
-    total_seconds_by_k: Dict[str, float]
-    embeddings_by_k: Dict[int | str, torch.Tensor]
-    cosine_to_full: Dict[str, float]
+    total_seconds_by_k: KFloatMap
+    embeddings_by_k: EmbeddingsByK
+    cosine_to_full: KFloatMap
+    cosine_consecutive: KFloatMap
     stability_k: int | None
     stability_seconds: float | None
     stability_threshold: float
     stability_epsilon: float
     stability_consecutive: int
+    stability_consecutive_k: int | None
+    stability_consecutive_seconds: float | None
+    stability_consecutive_threshold: float
 
 
 class SpeakerStabilitySummary(BaseModel):
@@ -70,13 +85,17 @@ class SpeakerStabilitySummary(BaseModel):
     representation: str
     model_name: str
     ks: List[int]
-    cosine_to_full: Dict[str, float]
-    total_seconds_by_k: Dict[str, float]
+    cosine_to_full: KFloatMap
+    cosine_consecutive: KFloatMap
+    total_seconds_by_k: KFloatMap
     stability_k: int | None
     stability_seconds: float | None
     stability_threshold: float
     stability_epsilon: float
     stability_consecutive: int
+    stability_consecutive_k: int | None
+    stability_consecutive_seconds: float | None
+    stability_consecutive_threshold: float
 
 
 class SpeakerStabilityCsvRow(BaseModel):
@@ -88,6 +107,7 @@ class SpeakerStabilityCsvRow(BaseModel):
     random_seed: int
     k: int
     cosine_to_full: float
+    cosine_consecutive: float | None
     cumulative_seconds: float
     num_utterances: int
     total_seconds: float
@@ -96,6 +116,9 @@ class SpeakerStabilityCsvRow(BaseModel):
     stability_threshold: float
     stability_epsilon: float
     stability_consecutive: int
+    stability_consecutive_k: int | None
+    stability_consecutive_seconds: float | None
+    stability_consecutive_threshold: float
 
 
 class SAASegmentationConfig(BaseModel):
@@ -122,4 +145,5 @@ class SpeakerStabilityConfig(BaseModel):
     stability_threshold: float = 0.95
     stability_epsilon: float = 0.002
     stability_consecutive: int = 2
+    stability_consecutive_threshold: float = 0.999
     saa_segmentation: SAASegmentationConfig | None = None

--- a/src/prosodic_feature_extraction/pipeline/speaker_stability.py
+++ b/src/prosodic_feature_extraction/pipeline/speaker_stability.py
@@ -17,16 +17,20 @@ from src.prosodic_feature_extraction.data.l2arctic_utils import list_l2arctic_sa
 from src.prosodic_feature_extraction.data.saa_segmentation import segment_saa_recording
 from src.prosodic_feature_extraction.data.saa_utils import load_saa_samples
 from src.prosodic_feature_extraction.features.incremental_embeddings import (
+    cosine_consecutive,
     cosine_to_full,
     normalize_embedding,
     running_centroids,
     select_k,
     stability_point,
+    stability_point_consecutive,
 )
 from src.prosodic_feature_extraction.features.utterance_embedding import mean_std_pool
 from src.prosodic_feature_extraction.metrics.similarity import cosine
 from src.prosodic_feature_extraction.models.prosody import L2ArcticSample, SAASample, SAASegmentSample
 from src.prosodic_feature_extraction.models.speaker_stability import (
+    EmbeddingsByK,
+    KFloatMap,
     RepresentationConfig,
     RepresentationEmbeddings,
     RepresentationRuntime,
@@ -367,9 +371,8 @@ def _append_csv_rows_from_summary(
     num_utterances: int,
     total_seconds: float,
 ) -> None:
-    for k_str, cosine_value in summary.cosine_to_full.items():
-        k = int(k_str)
-        cumulative_seconds_value = summary.total_seconds_by_k.get(k_str)
+    for k, cosine_value in summary.cosine_to_full.values.items():
+        cumulative_seconds_value = summary.total_seconds_by_k.values.get(k)
         if cumulative_seconds_value is None:
             continue
         rows.append(
@@ -382,6 +385,7 @@ def _append_csv_rows_from_summary(
                 random_seed=config.random_seed,
                 k=k,
                 cosine_to_full=cosine_value,
+                cosine_consecutive=summary.cosine_consecutive.values.get(k),
                 cumulative_seconds=cumulative_seconds_value,
                 num_utterances=num_utterances,
                 total_seconds=total_seconds,
@@ -390,6 +394,9 @@ def _append_csv_rows_from_summary(
                 stability_threshold=config.stability_threshold,
                 stability_epsilon=config.stability_epsilon,
                 stability_consecutive=config.stability_consecutive,
+                stability_consecutive_k=summary.stability_consecutive_k,
+                stability_consecutive_seconds=summary.stability_consecutive_seconds,
+                stability_consecutive_threshold=config.stability_consecutive_threshold,
             )
         )
 
@@ -410,6 +417,7 @@ def _process_representation(
     selected = select_k(centroids, config.ks)
     cosines_by_k = cosine_to_full(selected, full)
     cosines_all = [cosine(centroid, full) for centroid in centroids]
+    cosines_consec = cosine_consecutive(centroids)
 
     stable_k = stability_point(
         cosines_all,
@@ -419,11 +427,19 @@ def _process_representation(
     )
     stable_seconds = cumulative_seconds[stable_k - 1] if stable_k is not None else None
 
-    total_seconds_by_k = {
-        str(k): cumulative_seconds[k - 1]
+    stable_consec_k = stability_point_consecutive(
+        cosines_consec,
+        threshold=config.stability_consecutive_threshold,
+    )
+    stable_consec_seconds = (
+        cumulative_seconds[stable_consec_k - 1] if stable_consec_k is not None else None
+    )
+
+    total_seconds_by_k = KFloatMap(values={
+        k: cumulative_seconds[k - 1]
         for k in selected.keys()
         if k - 1 < len(cumulative_seconds)
-    }
+    })
 
     payload = SpeakerStabilityPayload(
         dataset=config.dataset,
@@ -437,26 +453,34 @@ def _process_representation(
         num_utterances=len(ordered_ids),
         total_seconds=cumulative_seconds[-1] if cumulative_seconds else 0.0,
         total_seconds_by_k=total_seconds_by_k,
-        embeddings_by_k=selected | {"full": full},
-        cosine_to_full={str(k): v for k, v in cosines_by_k.items()},
+        embeddings_by_k=EmbeddingsByK(by_k=selected, full=full),
+        cosine_to_full=KFloatMap(values=cosines_by_k),
+        cosine_consecutive=KFloatMap(values=cosines_consec),
         stability_k=stable_k,
         stability_seconds=stable_seconds,
         stability_threshold=config.stability_threshold,
         stability_epsilon=config.stability_epsilon,
         stability_consecutive=config.stability_consecutive,
+        stability_consecutive_k=stable_consec_k,
+        stability_consecutive_seconds=stable_consec_seconds,
+        stability_consecutive_threshold=config.stability_consecutive_threshold,
     )
     summary = SpeakerStabilitySummary(
         speaker_id=speaker_id,
         representation=runtime.config.name,
         model_name=runtime.config.model_name,
         ks=list(config.ks),
-        cosine_to_full={str(k): v for k, v in cosines_by_k.items()},
+        cosine_to_full=KFloatMap(values=cosines_by_k),
+        cosine_consecutive=KFloatMap(values=cosines_consec),
         total_seconds_by_k=total_seconds_by_k,
         stability_k=stable_k,
         stability_seconds=stable_seconds,
         stability_threshold=config.stability_threshold,
         stability_epsilon=config.stability_epsilon,
         stability_consecutive=config.stability_consecutive,
+        stability_consecutive_k=stable_consec_k,
+        stability_consecutive_seconds=stable_consec_seconds,
+        stability_consecutive_threshold=config.stability_consecutive_threshold,
     )
     return payload, summary
 
@@ -603,6 +627,12 @@ def parse_args(argv: Sequence[str]) -> SpeakerStabilityConfig:
         help="Number of consecutive plateau steps required.",
     )
     parser.add_argument(
+        "--stability-consecutive-threshold",
+        type=float,
+        default=0.999,
+        help="Cosine threshold for consecutive stability point.",
+    )
+    parser.add_argument(
         "--saa-segment-min-sec",
         type=float,
         default=None,
@@ -671,6 +701,7 @@ def parse_args(argv: Sequence[str]) -> SpeakerStabilityConfig:
         stability_threshold=parsed.stability_threshold,
         stability_epsilon=parsed.stability_epsilon,
         stability_consecutive=parsed.stability_consecutive,
+        stability_consecutive_threshold=parsed.stability_consecutive_threshold,
         saa_segmentation=saa_segmentation,
     )
     if not config.representations:


### PR DESCRIPTION
Add consecutive centroid stability analysis to speaker stability pipeline

  - Add cosine_consecutive() to measure s_k'' (centroid_k vs centroid_{k-1})
  - Add stability_point_consecutive() with configurable threshold (default 0.999)
  - Refactor Dict fields in models to typed KFloatMap and EmbeddingsByK Pydantic models
  - Fix floating-point cosine values exceeding 1.0 by clamping to [-1, 1] across all cosine functions