### PR TITLE
FiLM Adaptation

### DIFF
--- a/src/acoustic_feature_extraction/plots/plot_speaker_stability.py
+++ b/src/acoustic_feature_extraction/plots/plot_speaker_stability.py
@@ -5,7 +5,7 @@ import csv
 import sys
 from collections import defaultdict
 from pathlib import Path
-from typing import DefaultDict, Dict, Iterable, List, Sequence, Tuple
+from typing import DefaultDict, Dict, Iterable, List, Optional, Sequence, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -23,6 +23,7 @@ def _load_rows(csv_path: Path) -> List[Dict[str, str]]:
 
 def _group_curves(
     rows: Iterable[Dict[str, str]],
+    metric: str = "cosine_to_full",
 ) -> Dict[str, Dict[str, List[Tuple[float, float]]]]:
     grouped: DefaultDict[str, DefaultDict[str, List[Tuple[float, float]]]] = defaultdict(
         lambda: defaultdict(list)
@@ -31,7 +32,10 @@ def _group_curves(
         representation = row["representation"]
         speaker_id = row["speaker_id"]
         seconds = float(row["cumulative_seconds"])
-        cosine = float(row["cosine_to_full"])
+        raw = row.get(metric, "")
+        if not raw or raw.lower() in ("none", "nan"):
+            continue
+        cosine = float(raw)
         grouped[representation][speaker_id].append((seconds, cosine))
 
     out: Dict[str, Dict[str, List[Tuple[float, float]]]] = {}
@@ -40,6 +44,18 @@ def _group_curves(
         for speaker_id, curve in by_speaker.items():
             out[representation][speaker_id] = sorted(curve, key=lambda x: x[0])
     return out
+
+
+def _compute_stability_means(
+    rows: List[Dict[str, str]],
+    col: str,
+) -> Dict[str, float]:
+    sums: DefaultDict[str, List[float]] = defaultdict(list)
+    for row in rows:
+        val = row.get(col, "")
+        if val and val.lower() not in ("", "none", "nan"):
+            sums[row["representation"]].append(float(val))
+    return {rep: sum(vs) / len(vs) for rep, vs in sums.items() if vs}
 
 
 def _aggregate_stats(
@@ -136,6 +152,8 @@ def _plot_representation_curves(
     out_dir: Path,
     formats: List[str],
     x_max_seconds: float,
+    file_suffix: str = "",
+    stability_mean: Optional[float] = None,
 ) -> None:
     fig, ax = plt.subplots(figsize=(9, 6))
     for _, points in curves.items():
@@ -158,6 +176,15 @@ def _plot_representation_curves(
         label="Mean ± Std",
     )
 
+    if stability_mean is not None:
+        ax.axvline(
+            stability_mean,
+            color="#e05c5c",
+            linestyle="--",
+            linewidth=1.5,
+            label=f"Mean stability ≈ {stability_mean:.1f}s",
+        )
+
     ax.set_title(f"Embedding Stability by Speaker: {representation}")
     ax.set_xlabel("Cumulative Speech (seconds)")
     ax.set_ylabel("Cosine Similarity to E_full")
@@ -167,7 +194,8 @@ def _plot_representation_curves(
     ax.grid(True, alpha=0.3)
     ax.legend(loc="lower right")
 
-    file_stem = out_dir / f"stability_{_sanitize_filename(representation)}"
+    stem = f"stability_{_sanitize_filename(representation)}{file_suffix}"
+    file_stem = out_dir / stem
     _save_plot(fig, file_stem, formats)
 
 
@@ -177,9 +205,12 @@ def _plot_aggregate_comparison(
     out_dir: Path,
     formats: List[str],
     x_max_seconds: float,
+    file_stem_name: str = "stability_aggregate_mean_std",
+    stability_means: Optional[Dict[str, float]] = None,
 ) -> None:
     fig, ax = plt.subplots(figsize=(9, 6))
     all_curves: Dict[str, List[Tuple[float, float]]] = {}
+    rep_colors: Dict[str, str] = {}
     for representation, stats in sorted(stats_by_representation.items()):
         if not stats:
             continue
@@ -188,10 +219,22 @@ def _plot_aggregate_comparison(
         stds = np.array([s for _, _, s in stats], dtype=np.float64)
         lower = np.clip(means - stds, 0.0, 1.0)
         upper = np.clip(means + stds, 0.0, 1.0)
-        ax.plot(ks, means, linewidth=2.3, label=f"{representation} mean")
-        ax.fill_between(ks, lower, upper, alpha=0.18)
+        (line,) = ax.plot(ks, means, linewidth=2.3, label=f"{representation} mean")
+        rep_colors[representation] = line.get_color()
+        ax.fill_between(ks, lower, upper, alpha=0.18, color=line.get_color())
         for speaker_id, points in curves_by_representation[representation].items():
             all_curves[f"{representation}:{speaker_id}"] = points
+
+    if stability_means:
+        for representation, mean_s in sorted(stability_means.items()):
+            color = rep_colors.get(representation, "#888888")
+            ax.axvline(
+                mean_s,
+                color=color,
+                linestyle="--",
+                linewidth=1.5,
+                label=f"{representation} stability ≈ {mean_s:.1f}s",
+            )
 
     ax.set_title("Embedding Stability: Aggregate Mean ± Std")
     ax.set_xlabel("Cumulative Speech (seconds)")
@@ -202,7 +245,7 @@ def _plot_aggregate_comparison(
     ax.grid(True, alpha=0.3)
     ax.legend(loc="lower right")
 
-    file_stem = out_dir / "stability_aggregate_mean_std"
+    file_stem = out_dir / file_stem_name
     _save_plot(fig, file_stem, formats)
 
 
@@ -249,28 +292,51 @@ def main(argv: Sequence[str]) -> int:
     formats = [fmt.strip().lower() for fmt in str(args.formats).split(",") if fmt.strip()]
     x_max_seconds = float(args.x_max_seconds)
 
-    curves_by_rep = _group_curves(rows)
-    stats_by_rep: Dict[str, List[Tuple[float, float, float]]] = {}
-    for representation, curves in curves_by_rep.items():
-        stats = _aggregate_stats(curves, max_seconds=x_max_seconds)
-        stats_by_rep[representation] = stats
-        _plot_representation_curves(
-            representation=representation,
-            curves=curves,
-            stats=stats,
+    approaches = [
+        {
+            "metric": "cosine_to_full",
+            "stability_col": "stability_seconds",
+            "file_suffix": "",
+            "aggregate_stem": "stability_aggregate_mean_std",
+        },
+        {
+            "metric": "cosine_consecutive",
+            "stability_col": "stability_consecutive_seconds",
+            "file_suffix": "_consecutive",
+            "aggregate_stem": "stability_aggregate_consecutive",
+        },
+    ]
+
+    for approach in approaches:
+        curves_by_rep = _group_curves(rows, metric=approach["metric"])
+        stability_means = _compute_stability_means(rows, approach["stability_col"])
+        stats_by_rep: Dict[str, List[Tuple[float, float, float]]] = {}
+        for representation, curves in curves_by_rep.items():
+            stats = _aggregate_stats(curves, max_seconds=x_max_seconds)
+            stats_by_rep[representation] = stats
+            _plot_representation_curves(
+                representation=representation,
+                curves=curves,
+                stats=stats,
+                out_dir=out_dir,
+                formats=formats,
+                x_max_seconds=x_max_seconds,
+                file_suffix=approach["file_suffix"],
+                stability_mean=stability_means.get(representation),
+            )
+
+        _plot_aggregate_comparison(
+            stats_by_representation=stats_by_rep,
+            curves_by_representation=curves_by_rep,
             out_dir=out_dir,
             formats=formats,
             x_max_seconds=x_max_seconds,
+            file_stem_name=approach["aggregate_stem"],
+            stability_means=stability_means,
         )
+        if approach["file_suffix"] == "":
+            _write_aggregate_csv(out_dir / "stability_aggregate_stats.csv", stats_by_rep)
 
-    _plot_aggregate_comparison(
-        stats_by_representation=stats_by_rep,
-        curves_by_representation=curves_by_rep,
-        out_dir=out_dir,
-        formats=formats,
-        x_max_seconds=x_max_seconds,
-    )
-    _write_aggregate_csv(out_dir / "stability_aggregate_stats.csv", stats_by_rep)
     print(f"Saved plots and aggregate stats to {out_dir}")
     return 0
 

--- a/src/acoustic_feature_extraction/plots/plot_speaker_stability.py
+++ b/src/acoustic_feature_extraction/plots/plot_speaker_stability.py
@@ -220,7 +220,7 @@ def _plot_aggregate_comparison(
         lower = np.clip(means - stds, 0.0, 1.0)
         upper = np.clip(means + stds, 0.0, 1.0)
         (line,) = ax.plot(ks, means, linewidth=2.3, label=f"{representation} mean")
-        rep_colors[representation] = line.get_color()
+        rep_colors[representation] = str(line.get_color())
         ax.fill_between(ks, lower, upper, alpha=0.18, color=line.get_color())
         for speaker_id, points in curves_by_representation[representation].items():
             all_curves[f"{representation}:{speaker_id}"] = points

--- a/src/acoustic_feature_extraction/slurm/run_l2arctic_stability.sh
+++ b/src/acoustic_feature_extraction/slurm/run_l2arctic_stability.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# =============================================================================
+# run_l2arctic_stability.sh
+# Run speaker stability analysis on L2-ARCTIC for all three representations
+# (wavlm_base_meanstd, wavlm_sv_xvector, wav2vec2_meanstd) with dense k
+# checkpoints for smoother per-speaker curves in the stability plots.
+#
+# Submit with:  sbatch src/acoustic_feature_extraction/slurm/run_l2arctic_stability.sh
+# Monitor with: squeue -u $USER
+# =============================================================================
+
+#SBATCH --job-name=stability-l2arctic
+#SBATCH --time=02:00:00
+#SBATCH --mem=32G
+#SBATCH --cpus-per-task=4
+#SBATCH --gres=gpu:a100:1
+#SBATCH --partition=gpu_short
+#SBATCH --account=qu
+
+#SBATCH --chdir=/home/users/x/xenia1w/MastersThesis
+#SBATCH --output=/home/users/x/xenia1w/MastersThesis/logs/stability_l2arctic_%j.out
+#SBATCH --error=/home/users/x/xenia1w/MastersThesis/logs/stability_l2arctic_%j.err
+
+module load cuda/12.8
+
+set -euo pipefail
+
+PROJECT_DIR="/home/users/x/xenia1w/MastersThesis"
+cd "$PROJECT_DIR"
+
+export HF_HOME="$PROJECT_DIR/data/cache/huggingface"
+export TRANSFORMERS_OFFLINE=0
+
+source .venv/bin/activate
+
+mkdir -p logs
+
+echo "=== L2-ARCTIC stability started: $(date) ==="
+echo "Running on host: $(hostname)"
+
+uv run python -m src.acoustic_feature_extraction.pipeline.speaker_stability \
+    --dataset      l2arctic \
+    --ordering     chronological \
+    --ks           1,2,3,4,5,6,7,8,9,10,12,15,20
+
+echo "=== L2-ARCTIC stability finished: $(date) ==="

--- a/src/asr_adaptation/models/film_lora.py
+++ b/src/asr_adaptation/models/film_lora.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+from peft import PeftModel, PeftMixedModel
+from transformers import Wav2Vec2Processor
+
+from src.asr_adaptation.models.wav2vec_lora import (
+    DEFAULT_MODEL_NAME,
+    _LORA_ALPHA,
+    _LORA_DROPOUT,
+    _LORA_R,
+    _LORA_TARGET_MODULES,
+    build_lora_model,
+    trainable_parameter_summary,
+)
+
+__all__ = [
+    "FiLMConditionedLoraModel",
+    "build_film_lora_model",
+    "save_film_speaker_adapter",
+    "trainable_parameter_summary",
+]
+
+_N_LAYERS = 12
+_HIDDEN_SIZE = 768
+_MLP_HIDDEN = 128
+
+
+class FiLMConditionedLoraModel(nn.Module):
+    """
+    Wraps a PEFT LoRA model with FiLM (Feature-wise Linear Modulation) conditioning.
+
+    A two-layer MLP maps the 1536-dim speaker centroid to (γ_i, β_i) pairs for
+    each of the 12 encoder layers.  At each layer the modulation is applied after
+    final_layer_norm:  h = (1 + γ_i) * h + β_i
+
+    The last MLP linear is zero-initialized so γ=0, β=0 at the start of training,
+    preserving the model's pre-trained behaviour until the MLP learns to deviate.
+    LoRA adapters and the film_mlp are both trainable.
+    """
+
+    def __init__(
+        self,
+        peft_model: PeftModel | PeftMixedModel,
+        speaker_emb_dim: int = 1536,
+        n_layers: int = _N_LAYERS,
+        hidden_size: int = _HIDDEN_SIZE,
+        mlp_hidden: int = _MLP_HIDDEN,
+    ) -> None:
+        super().__init__()
+        self.model = peft_model
+        self._n_layers = n_layers
+        self._hidden_size = hidden_size
+
+        film_out = nn.Linear(mlp_hidden, n_layers * hidden_size * 2)
+        # Zero-init the output layer → identity transform at the start of training
+        nn.init.zeros_(film_out.weight)
+        nn.init.zeros_(film_out.bias)
+        self.film_mlp = nn.Sequential(
+            nn.Linear(speaker_emb_dim, mlp_hidden),
+            nn.ReLU(),
+            film_out,
+        )
+
+        self._film_params: torch.Tensor | None = None  # [N, 2, H] during forward
+
+        hooks_registered = 0
+        for name, module in peft_model.named_modules():
+            for i in range(n_layers):
+                if name.endswith(f"wav2vec2.encoder.layers.{i}.final_layer_norm"):
+                    module.register_forward_hook(self._make_hook(i))
+                    hooks_registered += 1
+                    break
+
+        if hooks_registered != n_layers:
+            raise RuntimeError(
+                f"Expected {n_layers} FiLM hooks but only registered {hooks_registered}. "
+                "Check that the PEFT model exposes wav2vec2.encoder.layers.*.final_layer_norm."
+            )
+
+    def _make_hook(self, layer_idx: int):
+        def hook(module, input, output):  # noqa: A002
+            if self._film_params is not None:
+                gamma = self._film_params[layer_idx, 0]  # [H] — broadcasts to [B, T, H]
+                beta = self._film_params[layer_idx, 1]   # [H]
+                return (1 + gamma) * output + beta
+            return output
+        return hook
+
+    @property
+    def config(self):
+        return self.model.config
+
+    def forward(
+        self,
+        input_values: torch.Tensor,
+        speaker_embedding: torch.Tensor | None = None,
+        labels: torch.Tensor | None = None,
+        **kwargs,
+    ):
+        # speaker_embedding: [D] for a single speaker centroid (training / inference)
+        if speaker_embedding is not None:
+            params = self.film_mlp(speaker_embedding)  # [N*H*2]
+            self._film_params = params.view(self._n_layers, 2, self._hidden_size)
+        else:
+            self._film_params = None
+        try:
+            return self.model(input_values=input_values, labels=labels, **kwargs)
+        finally:
+            self._film_params = None
+
+
+def build_film_lora_model(
+    model_name: str = DEFAULT_MODEL_NAME,
+    cache_dir: str | None = None,
+    speaker_emb_dim: int = 1536,
+    lora_r: int = _LORA_R,
+    lora_alpha: int = _LORA_ALPHA,
+    lora_dropout: float = _LORA_DROPOUT,
+    target_modules: list[str] | None = None,
+) -> tuple[FiLMConditionedLoraModel, Wav2Vec2Processor]:
+    """Load wav2vec2 with LoRA adapters wrapped in FiLM speaker conditioning."""
+    peft_model, processor = build_lora_model(
+        model_name=model_name,
+        cache_dir=cache_dir,
+        lora_r=lora_r,
+        lora_alpha=lora_alpha,
+        lora_dropout=lora_dropout,
+        target_modules=target_modules,
+    )
+    return FiLMConditionedLoraModel(peft_model, speaker_emb_dim=speaker_emb_dim), processor
+
+
+def save_film_speaker_adapter(
+    model: FiLMConditionedLoraModel,
+    speaker_id: str,
+    output_dir: str | Path,
+) -> Path:
+    """Save LoRA adapter weights and film_mlp for one speaker."""
+    save_path = Path(output_dir) / speaker_id
+    save_path.mkdir(parents=True, exist_ok=True)
+    model.model.save_pretrained(str(save_path))
+    torch.save(model.film_mlp.state_dict(), save_path / "film_mlp.pt")
+    return save_path

--- a/src/asr_adaptation/models/film_lora.py
+++ b/src/asr_adaptation/models/film_lora.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import torch
 import torch.nn as nn
 from peft import PeftModel, PeftMixedModel
-from transformers import Wav2Vec2Processor
+from transformers import Wav2Vec2ForCTC, Wav2Vec2Processor
 
 from src.asr_adaptation.models.wav2vec_lora import (
     DEFAULT_MODEL_NAME,
@@ -20,6 +20,7 @@ from src.asr_adaptation.models.wav2vec_lora import (
 __all__ = [
     "FiLMConditionedLoraModel",
     "build_film_lora_model",
+    "load_film_lora_model",
     "save_film_speaker_adapter",
     "trainable_parameter_summary",
 ]
@@ -132,6 +133,33 @@ def build_film_lora_model(
         target_modules=target_modules,
     )
     return FiLMConditionedLoraModel(peft_model, speaker_emb_dim=speaker_emb_dim), processor
+
+
+def load_film_lora_model(
+    speaker_id: str,
+    checkpoint_dir: str | Path,
+    model_name: str = DEFAULT_MODEL_NAME,
+    cache_dir: str | None = None,
+) -> tuple[FiLMConditionedLoraModel, Wav2Vec2Processor]:
+    """Load a previously saved FiLM-conditioned LoRA adapter for inference.
+
+    Args:
+        speaker_id: Subdirectory name used when saving, e.g. "ABA".
+        checkpoint_dir: Root directory containing per-speaker adapter subdirectories.
+        model_name: Base model identifier (must match training).
+        cache_dir: Optional local cache directory for base model weights.
+
+    Returns:
+        (film_model, processor) ready for inference — no training state.
+    """
+    adapter_dir = Path(checkpoint_dir) / speaker_id
+    base_model = Wav2Vec2ForCTC.from_pretrained(model_name, cache_dir=cache_dir)
+    processor = Wav2Vec2Processor.from_pretrained(model_name, cache_dir=cache_dir)
+    peft_model = PeftModel.from_pretrained(base_model, str(adapter_dir))
+    film_model = FiLMConditionedLoraModel(peft_model)
+    film_state = torch.load(adapter_dir / "film_mlp.pt", map_location="cpu", weights_only=True)
+    film_model.film_mlp.load_state_dict(film_state)
+    return film_model, processor
 
 
 def save_film_speaker_adapter(

--- a/src/asr_adaptation/pipeline/film_train.py
+++ b/src/asr_adaptation/pipeline/film_train.py
@@ -24,7 +24,7 @@ from src.asr_adaptation.pipeline.lora_train import (
 )
 
 _N_EVAL = 100
-_N_TRAIN_DEFAULT = 150
+_N_TRAIN_DEFAULT = None  # use all available training utterances
 _N_EPOCHS = 10
 _LEARNING_RATE = 1e-5
 _GRAD_ACCUM_STEPS = 4

--- a/src/asr_adaptation/pipeline/film_train.py
+++ b/src/asr_adaptation/pipeline/film_train.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+from loguru import logger
+
+from src.asr_adaptation.data.l2arctic_transcriptions import list_l2arctic_samples_with_transcripts
+from src.asr_adaptation.data.speaker_embeddings import compute_speaker_centroid
+from src.asr_adaptation.data.wav2vec2_speaker_embeddings import compute_speaker_centroid_wav2vec2
+from src.asr_adaptation.metrics.wer import compute_wer
+from src.asr_adaptation.models.film_lora import (
+    build_film_lora_model,
+    save_film_speaker_adapter,
+    trainable_parameter_summary,
+)
+from src.asr_adaptation.pipeline.lora_train import (
+    AdaptationRow,
+    _get_hypotheses,
+    _save_csv,
+    _split_samples,
+    _train_lora,
+)
+
+_N_EVAL = 100
+_N_TRAIN_DEFAULT = 150
+_N_EPOCHS = 10
+_LEARNING_RATE = 1e-5
+_GRAD_ACCUM_STEPS = 4
+
+
+def run_film_train(
+    speaker_id: str,
+    l2arctic_zip: str,
+    output_dir: str | Path,
+    cache_dir: str | None = None,
+    n_train: int | None = _N_TRAIN_DEFAULT,
+    n_eval: int = _N_EVAL,
+    n_epochs: int = _N_EPOCHS,
+    learning_rate: float = _LEARNING_RATE,
+    grad_accum_steps: int = _GRAD_ACCUM_STEPS,
+    seed: int = 0,
+    wavlm_model: str = "microsoft/wavlm-base-plus",
+    profile_extractor: str = "wav2vec2",
+    profile_layer: int = -1,
+    wrong_speaker_id: str | None = None,
+    no_profile: bool = False,
+) -> list[AdaptationRow]:
+    """
+    Fine-tune a FiLM-conditioned LoRA adapter for one speaker and evaluate WER.
+
+    Args:
+        speaker_id: L2-ARCTIC speaker ID, e.g. "ABA".
+        l2arctic_zip: Path to l2arctic_release_v5.0.zip.
+        output_dir: Root for saving LoRA weights and results CSV.
+        cache_dir: HuggingFace model cache directory.
+        n_train: Number of utterances for training. None = use all available.
+        n_eval: Number of utterances held out for evaluation.
+        n_epochs: Training epochs.
+        learning_rate: AdamW learning rate.
+        grad_accum_steps: Gradient accumulation steps.
+        seed: Random seed for shuffling the training pool.
+        profile_extractor: "wav2vec2" (default) or "wavlm".
+        profile_layer: Which encoder layer to extract the profile from (default -1 = last).
+        wrong_speaker_id: If set, use this speaker's centroid at eval time only (control experiment).
+        no_profile: Disable profile injection — LoRA-only mode.
+
+    Returns:
+        List of AdaptationRow, one per eval utterance.
+    """
+    output_dir = Path(output_dir)
+    torch.backends.cuda.matmul.allow_tf32 = False
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    logger.info(f"Speaker {speaker_id} | device: {device}")
+
+    logger.info(f"Loading utterances for {speaker_id} ...")
+    all_samples = list_l2arctic_samples_with_transcripts(l2arctic_zip, speaker_id)
+
+    if len(all_samples) <= n_eval:
+        raise ValueError(
+            f"Speaker {speaker_id} has only {len(all_samples)} utterances "
+            f"but n_eval={n_eval} — not enough data."
+        )
+
+    train_samples, eval_samples = _split_samples(all_samples, n_eval, n_train, seed)
+    actual_n_train = len(train_samples)
+    logger.info(f"Train: {actual_n_train} utterances | Eval: {len(eval_samples)} utterances")
+
+    # Compute speaker centroid from training utterances
+    if no_profile:
+        speaker_centroid = None
+        eval_centroid = None
+        logger.info("Profile injection disabled — running LoRA-only mode.")
+    elif profile_extractor == "wavlm":
+        speaker_centroid = compute_speaker_centroid(
+            train_samples, device=device, model_name=wavlm_model, cache_dir=cache_dir
+        ).to(device)
+        eval_centroid = speaker_centroid
+    else:
+        speaker_centroid = compute_speaker_centroid_wav2vec2(
+            train_samples, device=device, profile_layer=profile_layer, cache_dir=cache_dir
+        ).to(device)
+        eval_centroid = speaker_centroid
+
+    # Wrong-speaker control: compute a different centroid for eval (inference only)
+    if wrong_speaker_id is not None and not no_profile:
+        logger.info(f"Wrong-speaker control: loading centroid for {wrong_speaker_id} ...")
+        wrong_samples = list_l2arctic_samples_with_transcripts(l2arctic_zip, wrong_speaker_id)
+        wrong_train, _ = _split_samples(wrong_samples, n_eval, n_train, seed)
+        if profile_extractor == "wavlm":
+            eval_centroid = compute_speaker_centroid(
+                wrong_train, device=device, model_name=wavlm_model, cache_dir=cache_dir
+            ).to(device)
+        else:
+            eval_centroid = compute_speaker_centroid_wav2vec2(
+                wrong_train, device=device, profile_layer=profile_layer, cache_dir=cache_dir
+            ).to(device)
+        logger.info(f"Eval will use {wrong_speaker_id}'s centroid (wrong-speaker control).")
+
+    logger.info("Building FiLM-conditioned LoRA model ...")
+    model, processor = build_film_lora_model(cache_dir=cache_dir)
+    if no_profile:
+        for param in model.film_mlp.parameters():
+            param.requires_grad = False
+    torch.nn.Module.to(model, device)
+    summary = trainable_parameter_summary(model)
+    logger.info(
+        f"Trainable params: {summary['trainable']:,} / {summary['total']:,} "
+        f"({100 * summary['trainable'] / summary['total']:.2f}%)"
+    )
+
+    logger.info("Evaluating baseline (no adaptation) ...")
+    hypotheses_baseline = _get_hypotheses(model, eval_samples, processor, device, eval_centroid)
+
+    logger.info(f"Fine-tuning on {actual_n_train} utterances ...")
+    _train_lora(model, train_samples, processor, device, speaker_centroid, n_epochs, learning_rate, grad_accum_steps)
+
+    logger.info("Evaluating adapted model ...")
+    hypotheses_adapted = _get_hypotheses(model, eval_samples, processor, device, eval_centroid)
+
+    adapter_path = save_film_speaker_adapter(model, speaker_id, output_dir / "film_lora_weights")
+    logger.info(f"Saved FiLM adapter → {adapter_path}")
+
+    rows: list[AdaptationRow] = []
+    for sample, hyp_base, hyp_adapted in zip(eval_samples, hypotheses_baseline, hypotheses_adapted):
+        rows.append(
+            AdaptationRow(
+                speaker_id=speaker_id,
+                utterance_id=sample.utterance_id,
+                n_train=actual_n_train,
+                reference=sample.transcript,
+                hypothesis_baseline=hyp_base,
+                hypothesis_adapted=hyp_adapted,
+                wer_baseline=compute_wer([sample.transcript], [hyp_base]),
+                wer_adapted=compute_wer([sample.transcript], [hyp_adapted]),
+            )
+        )
+
+    avg_base = sum(r.wer_baseline for r in rows) / len(rows)
+    avg_adapted = sum(r.wer_adapted for r in rows) / len(rows)
+    logger.info(
+        f"Speaker {speaker_id} | "
+        f"baseline WER: {avg_base:.3f} → adapted WER: {avg_adapted:.3f} "
+        f"(delta: {avg_adapted - avg_base:+.3f})"
+    )
+
+    _save_csv(rows, output_dir / "film_adaptation_results" / f"{speaker_id}.csv")
+    return rows
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="FiLM-conditioned LoRA speaker adaptation for wav2vec2.")
+    parser.add_argument("--speaker-id", required=True, help="L2-ARCTIC speaker ID, e.g. ABA")
+    parser.add_argument("--l2arctic-zip", required=True, help="Path to l2arctic_release_v5.0.zip")
+    parser.add_argument("--output-dir", required=True, help="Root directory for saving weights and results")
+    parser.add_argument("--cache-dir", default=None, help="HuggingFace model cache directory")
+    parser.add_argument("--n-train", type=int, default=_N_TRAIN_DEFAULT, help="Max training utterances")
+    parser.add_argument("--n-eval", type=int, default=_N_EVAL, help="Held-out evaluation utterances")
+    parser.add_argument("--n-epochs", type=int, default=_N_EPOCHS, help="Training epochs")
+    parser.add_argument("--learning-rate", type=float, default=_LEARNING_RATE, help="AdamW learning rate")
+    parser.add_argument("--grad-accum-steps", type=int, default=_GRAD_ACCUM_STEPS, help="Gradient accumulation steps")
+    parser.add_argument("--seed", type=int, default=0, help="Random seed")
+    parser.add_argument("--wavlm-model", default="microsoft/wavlm-base-plus", help="WavLM model name (used with --profile-extractor wavlm)")
+    parser.add_argument("--profile-extractor", default="wav2vec2", help="Profile extractor: 'wav2vec2' (default) or 'wavlm'")
+    parser.add_argument("--profile-layer", type=int, default=-1, help="Encoder layer for profile extraction (default -1 = last)")
+    parser.add_argument("--wrong-speaker-id", default=None, help="Use this speaker's centroid at eval time (wrong-speaker control)")
+    parser.add_argument("--no-profile", action="store_true", help="LoRA-only mode: disable FiLM conditioning")
+
+    args = parser.parse_args()
+    run_film_train(
+        speaker_id=args.speaker_id,
+        l2arctic_zip=args.l2arctic_zip,
+        output_dir=args.output_dir,
+        cache_dir=args.cache_dir,
+        n_train=args.n_train,
+        n_eval=args.n_eval,
+        n_epochs=args.n_epochs,
+        learning_rate=args.learning_rate,
+        grad_accum_steps=args.grad_accum_steps,
+        seed=args.seed,
+        wavlm_model=args.wavlm_model,
+        profile_extractor=args.profile_extractor,
+        profile_layer=args.profile_layer,
+        wrong_speaker_id=args.wrong_speaker_id,
+        no_profile=args.no_profile,
+    )

--- a/src/asr_adaptation/pipeline/film_wrong_speaker.py
+++ b/src/asr_adaptation/pipeline/film_wrong_speaker.py
@@ -1,0 +1,204 @@
+"""Wrong-speaker control experiment for FiLM-conditioned LoRA.
+
+Loads a pre-trained FiLM+LoRA checkpoint for speaker A and re-transcribes their
+existing eval set using a different speaker B's centroid.  The correct-speaker
+results are read directly from the already-saved film_adaptation_results CSV,
+so only one new inference pass (with the wrong centroid) is needed.
+
+If FiLM has learned to use speaker-specific content, WER should increase when
+the wrong centroid is injected.  If WER is unchanged, FiLM helps structurally
+only and does not encode speaker-specific information.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+import torch
+from loguru import logger
+from pydantic import BaseModel, computed_field
+
+from src.asr_adaptation.data.l2arctic_transcriptions import list_l2arctic_samples_with_transcripts
+from src.asr_adaptation.data.wav2vec2_speaker_embeddings import compute_speaker_centroid_wav2vec2
+from src.asr_adaptation.inference.transcribe import transcribe
+from src.asr_adaptation.metrics.wer import compute_wer
+from src.asr_adaptation.models.film_lora import load_film_lora_model
+from src.asr_adaptation.pipeline.lora_train import _split_samples
+
+_N_EVAL = 100
+_N_TRAIN_DEFAULT = None
+
+
+class WrongSpeakerRow(BaseModel):
+    speaker_id: str
+    utterance_id: str
+    wrong_speaker_id: str
+    reference: str
+    hypothesis_correct: str
+    hypothesis_wrong: str
+    wer_correct: float
+    wer_wrong: float
+
+    @computed_field
+    @property
+    def wer_delta(self) -> float:
+        """Positive = wrong centroid hurt WER (model is using speaker content)."""
+        return self.wer_wrong - self.wer_correct
+
+
+def _load_existing_results(csv_path: Path) -> dict[str, dict]:
+    """Read the correct-speaker results CSV keyed by utterance_id."""
+    rows = {}
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            rows[row["utterance_id"]] = row
+    return rows
+
+
+def _save_csv(rows: list[WrongSpeakerRow], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fields = list(WrongSpeakerRow.model_fields) + ["wer_delta"]
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        for row in rows:
+            d = row.model_dump()
+            d["wer_correct"] = round(d["wer_correct"], 4)
+            d["wer_wrong"] = round(d["wer_wrong"], 4)
+            d["wer_delta"] = round(d["wer_delta"], 4)
+            writer.writerow(d)
+    logger.info(f"Saved {len(rows)} rows → {path}")
+
+
+def run_film_wrong_speaker(
+    speaker_id: str,
+    wrong_speaker_id: str,
+    l2arctic_zip: str,
+    checkpoint_dir: str | Path,
+    output_dir: str | Path,
+    cache_dir: str | None = None,
+    n_train: int | None = _N_TRAIN_DEFAULT,
+    n_eval: int = _N_EVAL,
+    seed: int = 0,
+    profile_layer: int = -1,
+) -> list[WrongSpeakerRow]:
+    """Run wrong-speaker control inference for one speaker pair (A model, B centroid).
+
+    Args:
+        speaker_id: Target speaker whose trained model and test set are used.
+        wrong_speaker_id: Speaker whose centroid is injected as the wrong profile.
+        l2arctic_zip: Path to l2arctic_release_v5.0.zip.
+        checkpoint_dir: Root directory containing film_lora_weights/ and film_adaptation_results/.
+        output_dir: Root for writing results CSV.
+        cache_dir: HuggingFace model cache directory.
+        n_train: Must match training value — used to compute the wrong speaker's centroid
+                 from the same number of utterances. (default: all available)
+        n_eval: Must match training value (default: 100).
+        seed: Must match training seed so the split is identical (default: 0).
+        profile_layer: Encoder layer for centroid extraction (default -1 = last).
+
+    Returns:
+        List of WrongSpeakerRow, one per eval utterance.
+    """
+    checkpoint_dir = Path(checkpoint_dir)
+    output_dir = Path(output_dir)
+    torch.backends.cuda.matmul.allow_tf32 = False
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    logger.info(f"Wrong-speaker control: {speaker_id} (model) ← {wrong_speaker_id} (centroid) | device: {device}")
+
+    # Load the existing correct-speaker results — no need to rerun inference
+    correct_csv = checkpoint_dir / "film_adaptation_results" / f"{speaker_id}.csv"
+    logger.info(f"Reading correct-speaker results from {correct_csv} ...")
+    correct_results = _load_existing_results(correct_csv)
+    eval_utterance_ids = set(correct_results.keys())
+    logger.info(f"Found {len(eval_utterance_ids)} eval utterances in existing CSV")
+
+    # Load speaker A's audio for the eval utterances only
+    logger.info(f"Loading audio for {speaker_id} eval set ...")
+    all_samples = list_l2arctic_samples_with_transcripts(l2arctic_zip, speaker_id)
+    eval_samples = [s for s in all_samples if s.utterance_id in eval_utterance_ids]
+    if not eval_samples:
+        raise ValueError(f"No eval samples found for {speaker_id} matching the existing CSV utterance IDs.")
+
+    # Compute the wrong speaker's centroid from their training utterances
+    logger.info(f"Loading utterances for wrong speaker {wrong_speaker_id} ...")
+    wrong_all = list_l2arctic_samples_with_transcripts(l2arctic_zip, wrong_speaker_id)
+    wrong_train, _ = _split_samples(wrong_all, n_eval, n_train, seed)
+    logger.info(f"Computing wrong centroid from {len(wrong_train)} utterances ...")
+    wrong_centroid = compute_speaker_centroid_wav2vec2(
+        wrong_train, device=device, profile_layer=profile_layer, cache_dir=cache_dir
+    ).to(device)
+
+    # Load pre-trained FiLM+LoRA — no retraining
+    logger.info(f"Loading FiLM+LoRA checkpoint for {speaker_id} ...")
+    model, processor = load_film_lora_model(
+        speaker_id,
+        checkpoint_dir=checkpoint_dir / "film_lora_weights",
+        cache_dir=cache_dir,
+    )
+    model.to(device)
+    model.eval()
+
+    # Single inference pass with the wrong centroid
+    logger.info(f"Transcribing eval set with {wrong_speaker_id}'s centroid ...")
+    hyps_wrong = [
+        transcribe(s.waveform, processor, model, device, speaker_embedding=wrong_centroid)
+        for s in eval_samples
+    ]
+
+    rows: list[WrongSpeakerRow] = []
+    for sample, hyp_wrong in zip(eval_samples, hyps_wrong):
+        correct = correct_results[sample.utterance_id]
+        rows.append(
+            WrongSpeakerRow(
+                speaker_id=speaker_id,
+                utterance_id=sample.utterance_id,
+                wrong_speaker_id=wrong_speaker_id,
+                reference=sample.transcript,
+                hypothesis_correct=correct["hypothesis_adapted"],
+                hypothesis_wrong=hyp_wrong,
+                wer_correct=float(correct["wer_adapted"]),
+                wer_wrong=compute_wer([sample.transcript], [hyp_wrong]),
+            )
+        )
+
+    avg_correct = sum(r.wer_correct for r in rows) / len(rows)
+    avg_wrong = sum(r.wer_wrong for r in rows) / len(rows)
+    logger.info(
+        f"{speaker_id}: correct-centroid WER={avg_correct:.3f}  "
+        f"wrong-centroid WER={avg_wrong:.3f}  "
+        f"delta={avg_wrong - avg_correct:+.3f}"
+    )
+
+    out_path = output_dir / "film_wrong_speaker_results" / f"{speaker_id}_wrong_{wrong_speaker_id}.csv"
+    _save_csv(rows, out_path)
+    return rows
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="FiLM wrong-speaker control inference (no retraining).")
+    parser.add_argument("--speaker-id", required=True, help="Target speaker (model owner and test set)")
+    parser.add_argument("--wrong-speaker-id", required=True, help="Speaker whose centroid is injected")
+    parser.add_argument("--l2arctic-zip", required=True, help="Path to l2arctic_release_v5.0.zip")
+    parser.add_argument("--checkpoint-dir", required=True, help="Root dir containing film_lora_weights/ and film_adaptation_results/")
+    parser.add_argument("--output-dir", required=True, help="Root dir for results CSV")
+    parser.add_argument("--cache-dir", default=None, help="HuggingFace model cache directory")
+    parser.add_argument("--n-train", type=int, default=_N_TRAIN_DEFAULT, help="Must match training value (for wrong speaker centroid computation)")
+    parser.add_argument("--n-eval", type=int, default=_N_EVAL, help="Must match training value")
+    parser.add_argument("--seed", type=int, default=0, help="Must match training seed")
+    parser.add_argument("--profile-layer", type=int, default=-1, help="Encoder layer for centroid extraction")
+
+    args = parser.parse_args()
+    run_film_wrong_speaker(
+        speaker_id=args.speaker_id,
+        wrong_speaker_id=args.wrong_speaker_id,
+        l2arctic_zip=args.l2arctic_zip,
+        checkpoint_dir=args.checkpoint_dir,
+        output_dir=args.output_dir,
+        cache_dir=args.cache_dir,
+        n_train=args.n_train,
+        n_eval=args.n_eval,
+        seed=args.seed,
+        profile_layer=args.profile_layer,
+    )

--- a/src/asr_adaptation/slurm/run_film_layer_sweep.sh
+++ b/src/asr_adaptation/slurm/run_film_layer_sweep.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# =============================================================================
+# run_film_layer_sweep.sh
+# Layer sweep for wav2vec2 profile extraction — tests which encoder layer
+# produces the most speaker-discriminative profile for FiLM conditioning.
+#
+# Runs on a representative subset of 6 speakers (indices 0-5).
+# Layer -1 (last) is already covered by run_film_speaker.sh.
+# Sweep: layers 4, 6, 9
+#
+# Submit all three layers (after the main FiLM job JOBID finishes):
+#   sbatch --dependency=afterok:JOBID --export=ALL,PROFILE_LAYER=4 --array=0-5 src/asr_adaptation/slurm/run_film_layer_sweep.sh
+#   sbatch --dependency=afterok:JOBID --export=ALL,PROFILE_LAYER=6 --array=0-5 src/asr_adaptation/slurm/run_film_layer_sweep.sh
+#   sbatch --dependency=afterok:JOBID --export=ALL,PROFILE_LAYER=9 --array=0-5 src/asr_adaptation/slurm/run_film_layer_sweep.sh
+#
+# Monitor: squeue -u $USER
+# =============================================================================
+
+#SBATCH --job-name=asr-film-sweep
+#SBATCH --time=01:00:00
+#SBATCH --mem=24G
+#SBATCH --cpus-per-task=4
+#SBATCH --gres=gpu:a100:1
+#SBATCH --partition=gpu_short
+#SBATCH --account=qu
+#SBATCH --chdir=/home/users/x/xenia1w/MastersThesis
+#SBATCH --output=/home/users/x/xenia1w/MastersThesis/logs/film_sweep_layer%x_%j.out
+#SBATCH --error=/home/users/x/xenia1w/MastersThesis/logs/film_sweep_layer%x_%j.err
+
+module load cuda/12.8
+
+set -euo pipefail
+
+# PROFILE_LAYER must be passed via --export=ALL,PROFILE_LAYER=N
+if [[ -z "${PROFILE_LAYER:-}" ]]; then
+    echo "ERROR: PROFILE_LAYER is not set. Pass it via --export=ALL,PROFILE_LAYER=N" >&2
+    exit 1
+fi
+
+SPEAKERS=(ABA ASI BWC EBVS ERMS HJK HKK HQTV LXC MBMPS NCC NJS PNV RRBI SKA SVBI THV TNI TXHC YBAA YDCK YKWK ZHAA TLV)
+SPEAKER="${SPEAKERS[$SLURM_ARRAY_TASK_ID]}"
+
+PROJECT_DIR="/home/users/x/xenia1w/MastersThesis"
+cd "$PROJECT_DIR"
+
+export HF_HOME="$PROJECT_DIR/data/cache/huggingface"
+export TRANSFORMERS_OFFLINE=1
+
+source .venv/bin/activate
+
+OUTPUT_DIR="data/processed/asr_adaptation_film_layer${PROFILE_LAYER}"
+
+mkdir -p logs \
+         "${OUTPUT_DIR}/film_lora_weights" \
+         "${OUTPUT_DIR}/film_adaptation_results"
+
+echo "=== FiLM layer sweep (layer=${PROFILE_LAYER}) for speaker $SPEAKER started: $(date) ==="
+echo "Array task ID: $SLURM_ARRAY_TASK_ID | Host: $(hostname)"
+
+python -m src.asr_adaptation.pipeline.film_train \
+    --speaker-id        "$SPEAKER" \
+    --l2arctic-zip      data/raw/l2arctic_release_v5.0.zip \
+    --output-dir        "$OUTPUT_DIR" \
+    --cache-dir         data/cache/huggingface \
+    --profile-extractor wav2vec2 \
+    --profile-layer     "$PROFILE_LAYER"
+
+echo "=== FiLM layer sweep (layer=${PROFILE_LAYER}) for speaker $SPEAKER finished: $(date) ==="

--- a/src/asr_adaptation/slurm/run_film_speaker.sh
+++ b/src/asr_adaptation/slurm/run_film_speaker.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# =============================================================================
+# run_film_speaker.sh
+# Per-speaker FiLM-conditioned LoRA fine-tuning using Wav2Vec2 acoustic profile.
+#
+# Submit all 24 speakers:
+#   sbatch --array=0-23 src/asr_adaptation/slurm/run_film_speaker.sh
+#
+# Submit a subset for testing (e.g. first 3 speakers):
+#   sbatch --array=0-2  src/asr_adaptation/slurm/run_film_speaker.sh
+#
+# Monitor: squeue -u $USER
+# =============================================================================
+
+#SBATCH --job-name=asr-film-w2v2
+#SBATCH --time=04:00:00
+#SBATCH --mem=24G
+#SBATCH --cpus-per-task=4
+#SBATCH --gres=gpu:a100:1
+#SBATCH --array=0-23
+#SBATCH --partition=gpu
+#SBATCH --account=qu
+#SBATCH --chdir=/home/users/x/xenia1w/MastersThesis
+#SBATCH --output=/home/users/x/xenia1w/MastersThesis/logs/film_%x_%j.out
+#SBATCH --error=/home/users/x/xenia1w/MastersThesis/logs/film_%x_%j.err
+
+module load cuda/12.8
+
+set -euo pipefail
+
+SPEAKERS=(ABA ASI BWC EBVS ERMS HJK HKK HQTV LXC MBMPS NCC NJS PNV RRBI SKA SVBI THV TNI TXHC YBAA YDCK YKWK ZHAA TLV)
+SPEAKER="${SPEAKERS[$SLURM_ARRAY_TASK_ID]}"
+
+PROJECT_DIR="/home/users/x/xenia1w/MastersThesis"
+cd "$PROJECT_DIR"
+
+export HF_HOME="$PROJECT_DIR/data/cache/huggingface"
+export TRANSFORMERS_OFFLINE=1
+
+source .venv/bin/activate
+
+mkdir -p logs \
+         data/processed/asr_adaptation_film/film_lora_weights \
+         data/processed/asr_adaptation_film/film_adaptation_results
+
+echo "=== FiLM training for speaker $SPEAKER started: $(date) ==="
+echo "Array task ID: $SLURM_ARRAY_TASK_ID | Host: $(hostname)"
+
+python -m src.asr_adaptation.pipeline.film_train \
+    --speaker-id        "$SPEAKER" \
+    --l2arctic-zip      data/raw/l2arctic_release_v5.0.zip \
+    --output-dir        data/processed/asr_adaptation_film \
+    --cache-dir         data/cache/huggingface \
+    --profile-extractor wav2vec2
+
+echo "=== FiLM training for speaker $SPEAKER finished: $(date) ==="

--- a/src/asr_adaptation/slurm/run_film_speaker.sh
+++ b/src/asr_adaptation/slurm/run_film_speaker.sh
@@ -13,12 +13,12 @@
 # =============================================================================
 
 #SBATCH --job-name=asr-film-w2v2
-#SBATCH --time=04:00:00
+#SBATCH --time=01:00:00
 #SBATCH --mem=24G
 #SBATCH --cpus-per-task=4
 #SBATCH --gres=gpu:a100:1
 #SBATCH --array=0-23
-#SBATCH --partition=gpu
+#SBATCH --partition=gpu_short
 #SBATCH --account=qu
 #SBATCH --chdir=/home/users/x/xenia1w/MastersThesis
 #SBATCH --output=/home/users/x/xenia1w/MastersThesis/logs/film_%x_%j.out

--- a/src/asr_adaptation/slurm/run_film_speaker.sh
+++ b/src/asr_adaptation/slurm/run_film_speaker.sh
@@ -13,12 +13,12 @@
 # =============================================================================
 
 #SBATCH --job-name=asr-film-w2v2
-#SBATCH --time=01:00:00
+#SBATCH --time=04:00:00
 #SBATCH --mem=24G
 #SBATCH --cpus-per-task=4
 #SBATCH --gres=gpu:a100:1
 #SBATCH --array=0-23
-#SBATCH --partition=gpu_short
+#SBATCH --partition=gpu
 #SBATCH --account=qu
 #SBATCH --chdir=/home/users/x/xenia1w/MastersThesis
 #SBATCH --output=/home/users/x/xenia1w/MastersThesis/logs/film_%x_%j.out

--- a/src/asr_adaptation/slurm/run_film_wrong_speaker.sh
+++ b/src/asr_adaptation/slurm/run_film_wrong_speaker.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# =============================================================================
+# run_film_wrong_speaker.sh
+# Wrong-speaker control experiment: load the trained FiLM+LoRA for each speaker
+# and run inference on their test set using the *next* speaker's centroid
+# (circular rotation), then compare WER to the correct-centroid baseline.
+#
+# Interpretation:
+#   wer_delta > 0  →  wrong centroid hurt WER  →  FiLM uses speaker content ✓
+#   wer_delta ≈ 0  →  model ignores profile    →  FiLM helps structurally only
+#
+# Submit all 24 speaker pairs:
+#   sbatch --array=0-23 src/asr_adaptation/slurm/run_film_wrong_speaker.sh
+#
+# Submit a single pair for a quick sanity check (e.g. ABA ← ASI):
+#   sbatch --array=0-0  src/asr_adaptation/slurm/run_film_wrong_speaker.sh
+#
+# Monitor: squeue -u $USER
+# =============================================================================
+
+#SBATCH --job-name=film-wrong-spk
+#SBATCH --time=02:00:00
+#SBATCH --mem=24G
+#SBATCH --cpus-per-task=4
+#SBATCH --gres=gpu:a100:1
+#SBATCH --array=0-23
+#SBATCH --partition=gpu
+#SBATCH --account=qu
+#SBATCH --chdir=/home/users/x/xenia1w/MastersThesis
+#SBATCH --output=/home/users/x/xenia1w/MastersThesis/logs/film_wrong_%x_%j.out
+#SBATCH --error=/home/users/x/xenia1w/MastersThesis/logs/film_wrong_%x_%j.err
+
+module load cuda/12.8
+
+set -euo pipefail
+
+# PROFILE_LAYER controls which layer the wrong centroid is extracted from.
+# Defaults to -1 (last layer) to match the original FiLM training.
+# Override via: --export=ALL,PROFILE_LAYER=6
+PROFILE_LAYER="${PROFILE_LAYER:--1}"
+
+# Resolve checkpoint/output dir from layer
+if [[ "$PROFILE_LAYER" == "-1" ]]; then
+    DATA_DIR="data/processed/asr_adaptation_film"
+else
+    DATA_DIR="data/processed/asr_adaptation_film_layer${PROFILE_LAYER}"
+fi
+
+SPEAKERS=(ABA ASI BWC EBVS ERMS HJK HKK HQTV LXC MBMPS NCC NJS PNV RRBI SKA SVBI THV TNI TXHC YBAA YDCK YKWK ZHAA TLV)
+N=${#SPEAKERS[@]}
+
+# Each speaker gets the *next* speaker's centroid (circular)
+SPEAKER="${SPEAKERS[$SLURM_ARRAY_TASK_ID]}"
+WRONG_IDX=$(( (SLURM_ARRAY_TASK_ID + 1) % N ))
+WRONG_SPEAKER="${SPEAKERS[$WRONG_IDX]}"
+
+PROJECT_DIR="/home/users/x/xenia1w/MastersThesis"
+cd "$PROJECT_DIR"
+
+export HF_HOME="$PROJECT_DIR/data/cache/huggingface"
+export TRANSFORMERS_OFFLINE=1
+
+source .venv/bin/activate
+
+mkdir -p logs "${DATA_DIR}/film_wrong_speaker_results"
+
+echo "=== Wrong-speaker control (layer=${PROFILE_LAYER}): $SPEAKER (model) ← $WRONG_SPEAKER (centroid) started: $(date) ==="
+echo "Array task ID: $SLURM_ARRAY_TASK_ID | Host: $(hostname)"
+
+python -m src.asr_adaptation.pipeline.film_wrong_speaker \
+    --speaker-id        "$SPEAKER" \
+    --wrong-speaker-id  "$WRONG_SPEAKER" \
+    --l2arctic-zip      data/raw/l2arctic_release_v5.0.zip \
+    --checkpoint-dir    "$DATA_DIR" \
+    --output-dir        "$DATA_DIR" \
+    --cache-dir         data/cache/huggingface \
+    --profile-layer     "$PROFILE_LAYER"
+
+echo "=== Wrong-speaker control (layer=${PROFILE_LAYER}): $SPEAKER ← $WRONG_SPEAKER finished: $(date) ==="


### PR DESCRIPTION
New files:
  - src/asr_adaptation/models/film_lora.py — New model architecture combining FiLM conditioning with LoRA (replacing the previous additive speaker injection with an MLP-based
  approach)
  - src/asr_adaptation/pipeline/film_train.py — Training pipeline for the FiLM model
  - src/asr_adaptation/pipeline/film_wrong_speaker.py — Pipeline to evaluate what happens when a "wrong" (mismatched) speaker profile is injected — tests how much the profile
  actually contributes
  - src/asr_adaptation/slurm/run_film_layer_sweep.sh — Slurm job to sweep over different Whisper encoder layers for profile injection
  - src/asr_adaptation/slurm/run_film_speaker.sh — Slurm job to train the FiLM model across all 24 speakers
  - src/asr_adaptation/slurm/run_film_wrong_speaker.sh — Slurm job for the wrong-speaker experiment across speakers

  Modified files:
  - plots/plot_speaker_stability.py — Extended (112 → ~135 lines effective) to support stability analysis plots