### PR TITLE
Merge post-hoc into fix-loader

### DIFF
--- a/scripts/analyze_posthoc.sh
+++ b/scripts/analyze_posthoc.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Re-score and summarise the post-hoc LLM-correction experiment (RQ2).
+# Safe to run live: always re-scores against the freshly merged prompted_all.csv,
+# so the numbers can never be stale. Usage: bash scripts/analyze_posthoc.sh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+V2=data/processed/lexical_stylistic_prompting/v2
+POSTHOC="$V2/earnings21_window_posthoc_blind"
+
+echo "==> 1/3  re-merging per-call post-hoc files (guards against a partial merge)"
+uv run python - <<'PY'
+import glob, pandas as pd
+d = "data/processed/lexical_stylistic_prompting/v2/earnings21_window_posthoc_blind"
+files = sorted(glob.glob(f"{d}/posthoc_[0-9]*.csv"))
+pd.concat([pd.read_csv(f) for f in files]).to_csv(f"{d}/prompted_all.csv", index=False)
+print(f"    merged {len(files)} calls -> prompted_all.csv")
+PY
+
+echo "==> 2/3  re-scoring baseline vs post-hoc against the golden references"
+uv run -m src.lexical_stylistic_prompting.pipeline.earnings21_window_score \
+    --annotations manual_annotation.csv \
+    --approach posthoc_blind
+
+echo "==> 3/3  summary"
+uv run python - <<'PY'
+import pandas as pd
+V2 = "data/processed/lexical_stylistic_prompting/v2"
+P  = f"{V2}/earnings21_window_posthoc_blind/prompted_all.csv"
+S  = f"{V2}/scores/cross_approach_summary.csv"
+
+g = pd.read_csv(P)
+print("\n--- how much did the LLM actually change? ---")
+print(f"  calls              : {len(g)}")
+print(f"  guard reverted     : {int(g.guard_applied.sum())} ({g.guard_applied.mean()*100:.0f}%)")
+print(f"  edit_ratio med/max : {g.edit_ratio.median():.3f} / {g.edit_ratio.max():.3f}")
+
+s = pd.read_csv(S)
+print("\n--- WER / Entity Error Rate: baseline -> post-hoc ---")
+for _, r in s.iterrows():
+    print(f"  [{r.approach}]  n={int(r.n)}")
+    print(f"    WER  {r.wer_base:.4f} -> {r.wer_prom:.4f}  (dmicro {r.wer_d_micro:+.4f})  p={r.p_wer:.3f}")
+    print(f"    EER  {r.eer_base:.4f} -> {r.eer_prom:.4f}  (dmicro {r.eer_d_micro:+.4f})  p={r.p_eer:.3f}")
+print("\n  (negative delta = improvement; p<0.05 = statistically significant)")
+PY

--- a/src/lexical_stylistic_prompting/data/earnings21_utils.py
+++ b/src/lexical_stylistic_prompting/data/earnings21_utils.py
@@ -14,10 +14,18 @@ SAMPLE_RATE = 16_000
 RTTM_MERGE_GAP = 2.0   # merge consecutive same-speaker RTTM segments within this gap
 MAX_SEGMENT_DURATION = 30.0  # split turns longer than this for Whisper
 
-# Entity types that represent genuine vocabulary challenges for ASR
+# Entity types counted by the Entity Error Rate. Rule: include every genuine semantic
+# named-entity category the corpus annotates, and exclude pure number/formatting normalization
+# tags whose "errors" are normalization artifacts rather than recognition failures. This keeps
+# the metric a true *entity* error rate while avoiding an arbitrary hand-picked subset.
+# Semantic types kept include MONEY/DATE/TIME/YEAR (a wrong amount or year is a content error).
+# Excluded by design: CONTRACTION, CARDINAL, PERCENT, ORDINAL, ALPHANUMERIC, RANGE, QUANTITY
+# (number/measurement normalization — e.g. "three miles", "165 feet"); FALLBACK (symbols +
+# partial-word disfluencies such as "profitab-"); TWITTER (2 web-handle fragments, negligible).
 VOCABULARY_ENTITY_TYPES = {
     "ORG", "PERSON", "PRODUCT", "GPE", "LOC", "FAC",
     "WEBSITE", "ABBREVIATION", "MONEY", "DATE", "TIME", "YEAR",
+    "NORP", "EVENT", "LAW", "WORK_OF_ART", "LANGUAGE",
 }
 
 

--- a/src/lexical_stylistic_prompting/models/constants.py
+++ b/src/lexical_stylistic_prompting/models/constants.py
@@ -17,6 +17,12 @@ LLM_TIMEOUT_SECONDS = 120
 LLM_MAX_RETRIES = 3
 LLM_RETRY_WAIT_SECONDS = 10
 
+# KISSKI enforces per-minute/hour/day request caps (headers report ~10/min, 200/hour, 400/day).
+# Throttle the client to stay just under the per-minute cap, and retry with header-driven
+# back-off when a 429 still slips through, so long batch runs pace themselves instead of crashing.
+KISSKI_REQUESTS_PER_MINUTE = 9        # one below the 10/min cap for safety margin
+LLM_RATE_LIMIT_MAX_RETRIES = 12       # a 429 is transient; retry generously (does not count as failure)
+
 # Whisper's decoder prompt window is ~224 tokens and end-weighted. Keep the injected
 # keyword list comfortably under that so it always fits and biasing stays effective.
 MAX_PROMPT_TOKENS = 200

--- a/src/lexical_stylistic_prompting/models/prompts.py
+++ b/src/lexical_stylistic_prompting/models/prompts.py
@@ -144,3 +144,44 @@ Raw ASR transcript chunk:
 
 {chunk}"""
 
+# Self-contained "context" variant: the same strict verbatim correction, but the chunk is
+# accompanied by a REFERENCE transcript — the unprompted Whisper output for the first five
+# minutes (0:00-5:00) of the SAME call. That preamble (operator script, speaker introductions,
+# company name) is entity-dense, so it hints at how names/terms recur in this call. Crucially
+# the reference is itself raw ASR and may carry the same errors, so the prompt forbids copying
+# from it and treats it as a hint only. This is the post-hoc counterpart of the transcript_only
+# prompting method (same 0-5 transcript, injected after decoding instead of via initial_prompt).
+
+POSTHOC_CONTEXT_SYSTEM = """\
+You correct automatic-speech-recognition (ASR) errors in earnings-call transcripts.
+
+You are given a chunk of a raw ASR transcript to correct, together with a REFERENCE transcript \
+of the opening of the SAME call (its first few minutes). The reference is itself raw ASR and may \
+contain its own errors. Use it ONLY as a hint for how company names, people, product and ticker \
+names, and recurring terms appear in this call. Do NOT copy from the reference and do NOT insert \
+its words where they were not spoken in the chunk.
+
+Return the SAME chunk text with only genuine recognition errors fixed. This is a verbatim \
+transcript, not an edit for readability.
+
+Rules:
+- Preserve wording exactly: same words, same order. Do NOT paraphrase, rephrase, summarize, \
+translate, reorder, or "clean up" grammar.
+- Keep disfluencies and false starts verbatim (um, uh, "we-we", repeated words, incomplete \
+sentences). Do NOT remove filler words.
+- Do NOT add or delete content. The output length must closely match the input.
+- Only fix words that were clearly MIS-HEARD: misrecognized common words, company/product/person \
+names, ticker symbols, financial terms and abbreviations, and numbers.
+- Keep the same casing and punctuation style as the input; do not re-punctuate.
+- If a passage is already correct, return it unchanged.
+- Output ONLY the corrected transcript chunk, with no preamble, notes, or quotation marks."""
+
+POSTHOC_CONTEXT_USER = """\
+Reference transcript (first minutes of the same call, raw ASR — may contain errors, use as a hint only):
+
+{reference}
+
+Raw ASR transcript chunk to correct:
+
+{chunk}"""
+

--- a/src/lexical_stylistic_prompting/models/prompts.py
+++ b/src/lexical_stylistic_prompting/models/prompts.py
@@ -185,3 +185,45 @@ Raw ASR transcript chunk to correct:
 
 {chunk}"""
 
+# Profile variant: the chunk is corrected using a CURATED entity profile rather than the raw
+# 0:00-5:00 transcript. The profile is the LLM-built, spell-corrected transcript_metadata_knowledge
+# list for the SAME call (company, ticker, executive, product names, financial abbreviations). Unlike
+# the raw-transcript context reference, this profile is authoritative: it is the corrector's canonical
+# spelling of exactly the entities that drive entity error rate, so — the opposite of the context
+# prompt — the model is told to TRUST it and adopt its spellings for any entity it recognises as
+# mis-heard. This is the post-hoc counterpart of injecting the same profile into Whisper's
+# initial_prompt (RQ2: one profile, two injection points — decode-time vs post-decode correction).
+
+POSTHOC_PROFILE_SYSTEM = """\
+You correct automatic-speech-recognition (ASR) errors in earnings-call transcripts.
+
+You are given a chunk of a raw ASR transcript to correct, together with a PROFILE of this call: a \
+curated list of the company, ticker, executive, product, and domain-specific terms it contains, \
+with their correct spelling. Treat the profile as authoritative: when a word in the chunk is a \
+mis-heard version of a profile term, replace it with the profile's spelling.  \
+
+Return the SAME chunk text with only genuine recognition errors fixed. This is a verbatim \
+transcript, not an edit for readability.
+
+Rules:
+- Preserve wording exactly: same words, same order. Do NOT paraphrase, rephrase, summarize, \
+translate, reorder, or "clean up" grammar.
+- Keep disfluencies and false starts verbatim (um, uh, "we-we", repeated words, incomplete \
+sentences). Do NOT remove filler words.
+- Do NOT add or delete content. The output length must closely match the input.
+- Only fix words that were clearly MIS-HEARD: misrecognized common words, and especially \
+company/product/person names, ticker symbols, financial terms and abbreviations, and numbers — \
+using the profile's spelling for any entity it lists.
+- Keep the same casing and punctuation style as the input; do not re-punctuate.
+- If a passage is already correct, return it unchanged.
+- Output ONLY the corrected transcript chunk, with no preamble, notes, or quotation marks."""
+
+POSTHOC_PROFILE_USER = """\
+Profile of this call (authoritative spellings of the entities and terms it contains):
+
+{profile}
+
+Raw ASR transcript chunk to correct:
+
+{chunk}"""
+

--- a/src/lexical_stylistic_prompting/models/prompts.py
+++ b/src/lexical_stylistic_prompting/models/prompts.py
@@ -112,3 +112,35 @@ commonly mis-transcribe.
 
 {format_rules}
 """
+
+
+# ── post-hoc correction (RQ2 extension) ────────────────────────────────────────
+# Conservative, verbatim ASR error-correction of a single (1-best) Whisper hypothesis.
+# The reference is verbatim .nlp text (disfluencies, exact spoken wording), so the model
+# must NOT rewrite/clean up — only fix clear recognition errors. See arXiv 2409.09554 /
+# 2307.04172: over-correction (rewriting already-correct words) is the main failure mode
+# with a single hypothesis, so edit freedom is tightly constrained.
+
+POSTHOC_CORRECT_SYSTEM = """\
+You correct automatic-speech-recognition (ASR) errors in earnings-call transcripts.
+
+You are given a chunk of a raw ASR transcript. Return the SAME text with only genuine \
+recognition errors fixed. This is a verbatim transcript, not an edit for readability.
+
+Rules:
+- Preserve wording exactly: same words, same order. Do NOT paraphrase, rephrase, summarize, \
+translate, reorder, or "clean up" grammar.
+- Keep disfluencies and false starts verbatim (um, uh, "we-we", repeated words, incomplete \
+sentences). Do NOT remove filler words.
+- Do NOT add or delete content. The output length must closely match the input.
+- Only fix words that were clearly MIS-HEARD: misrecognized common words, company/product/person \
+names, ticker symbols, financial terms and abbreviations, and numbers.
+- Keep the same casing and punctuation style as the input; do not re-punctuate.
+- If a passage is already correct, return it unchanged.
+- Output ONLY the corrected transcript text, with no preamble, notes, or quotation marks."""
+
+POSTHOC_CORRECT_USER = """\
+Raw ASR transcript chunk:
+
+{chunk}"""
+

--- a/src/lexical_stylistic_prompting/models/speaker_profile.py
+++ b/src/lexical_stylistic_prompting/models/speaker_profile.py
@@ -18,13 +18,15 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 from loguru import logger
-from openai import APITimeoutError, OpenAI
+from openai import APITimeoutError, OpenAI, RateLimitError
 from pydantic import BaseModel
 
 from src.lexical_stylistic_prompting.models.constants import (
     DEFAULT_LLM_MODEL,
     KISSKI_BASE_URL,
+    KISSKI_REQUESTS_PER_MINUTE,
     LLM_MAX_RETRIES,
+    LLM_RATE_LIMIT_MAX_RETRIES,
     LLM_RETRY_WAIT_SECONDS,
     LLM_TIMEOUT_SECONDS,
     MAX_PROMPT_TERMS,
@@ -98,10 +100,43 @@ def _get_client() -> OpenAI:
     )
 
 
-def _llm_call(client: OpenAI, model: str, system: str, user: str) -> str:
-    for attempt in range(1, LLM_MAX_RETRIES + 1):
+# Client-side throttle so batch runs stay under KISSKI's per-minute request cap. Shared across
+# all callers in the process (single-threaded); enforces a minimum gap between requests.
+_MIN_REQUEST_INTERVAL = 60.0 / KISSKI_REQUESTS_PER_MINUTE
+_last_request_time = 0.0
+
+
+def _throttle() -> None:
+    global _last_request_time
+    wait = _MIN_REQUEST_INTERVAL - (time.monotonic() - _last_request_time)
+    if wait > 0:
+        time.sleep(wait)
+    _last_request_time = time.monotonic()
+
+
+def _retry_after_seconds(err: RateLimitError) -> float | None:
+    """Seconds to wait from a 429's headers (retry-after / ratelimit-reset), if present."""
+    response = getattr(err, "response", None)
+    headers = getattr(response, "headers", None)
+    if not headers:
+        return None
+    for key in ("retry-after", "ratelimit-reset", "x-ratelimit-reset"):
+        value = headers.get(key)
+        if value:
+            try:
+                return float(value) + 1.0  # small buffer past the reset boundary
+            except ValueError:
+                continue
+    return None
+
+
+def _llm_call(client: OpenAI, model: str, system: str, user: str, max_tokens: int = 160) -> str:
+    timeout_attempts = 0
+    rate_limit_attempts = 0
+    while True:
+        _throttle()
         try:
-            logger.info(f"Sending request to KISSKI ({model}), attempt {attempt}/{LLM_MAX_RETRIES} ...")
+            logger.debug(f"Sending request to KISSKI ({model}) ...")
             response = client.chat.completions.create(
                 model=model,
                 messages=[
@@ -109,7 +144,7 @@ def _llm_call(client: OpenAI, model: str, system: str, user: str) -> str:
                     {"role": "user", "content": user},
                 ],
                 temperature=0.2,
-                max_tokens=160,
+                max_tokens=max_tokens,
                 # No frequency penalty: it penalizes the reused comma/space tokens in a
                 # list and pushes the model into prose ("clean terms, then a sentence").
                 frequency_penalty=0.0,
@@ -119,11 +154,19 @@ def _llm_call(client: OpenAI, model: str, system: str, user: str) -> str:
             assert content is not None, "LLM returned empty content"
             return content.strip()
         except APITimeoutError:
-            if attempt == LLM_MAX_RETRIES:
+            timeout_attempts += 1
+            if timeout_attempts >= LLM_MAX_RETRIES:
                 raise
             logger.warning(f"KISSKI timed out, retrying in {LLM_RETRY_WAIT_SECONDS}s ...")
             time.sleep(LLM_RETRY_WAIT_SECONDS)
-    raise RuntimeError("unreachable")
+        except RateLimitError as err:
+            rate_limit_attempts += 1
+            if rate_limit_attempts > LLM_RATE_LIMIT_MAX_RETRIES:
+                raise
+            wait = _retry_after_seconds(err) or LLM_RETRY_WAIT_SECONDS
+            logger.warning(f"KISSKI rate-limited (429), attempt {rate_limit_attempts}/"
+                           f"{LLM_RATE_LIMIT_MAX_RETRIES}, waiting {wait:.0f}s ...")
+            time.sleep(wait)
 
 
 @lru_cache(maxsize=1)

--- a/src/lexical_stylistic_prompting/pipeline/earnings21_posthoc_correct.py
+++ b/src/lexical_stylistic_prompting/pipeline/earnings21_posthoc_correct.py
@@ -20,10 +20,22 @@ Design (see arXiv 2409.09554 / 2307.04172):
 - Sentence-boundary chunking (~200 words) keeps each LLM call short so verbatim discipline
   holds and output length can't drift/truncate over a long span.
 
+Two modes:
+- blind (default): the LLM sees only the eval-window chunk (writes to earnings21_window_posthoc_blind).
+- context (--use-context): each chunk is corrected with the unprompted 0:00-5:00 transcript of the
+  SAME call as an in-prompt reference — self-contained (no metadata, no LLM-built profile), the
+  post-hoc counterpart of the transcript_only prompting method. Writes to
+  earnings21_window_posthoc_context. The reference is raw ASR, so the prompt treats it as a hint
+  only and forbids copying from it.
+
 Usage:
+    # blind
+    uv run -m src.lexical_stylistic_prompting.pipeline.earnings21_posthoc_correct --skip-existing
+    # context (0:00-5:00 self-reference)
     uv run -m src.lexical_stylistic_prompting.pipeline.earnings21_posthoc_correct \\
-        --baseline data/processed/lexical_stylistic_prompting/v2/earnings21_window_baseline/baseline_all.csv \\
-        --skip-existing
+        --use-context --skip-existing
+
+Score either with earnings21_window_score.py --approach posthoc_blind / posthoc_context.
 """
 
 from __future__ import annotations
@@ -31,6 +43,7 @@ from __future__ import annotations
 import argparse
 import csv
 import glob
+import json
 import re
 from pathlib import Path
 
@@ -42,6 +55,8 @@ from pydantic import BaseModel
 from src.asr_adaptation.metrics.wer import compute_wer
 from src.lexical_stylistic_prompting.models.constants import DEFAULT_LLM_MODEL
 from src.lexical_stylistic_prompting.models.prompts import (
+    POSTHOC_CONTEXT_SYSTEM,
+    POSTHOC_CONTEXT_USER,
     POSTHOC_CORRECT_SYSTEM,
     POSTHOC_CORRECT_USER,
 )
@@ -53,6 +68,15 @@ DEFAULT_BASELINE = Path(
 DEFAULT_OUT_DIR = Path(
     "data/processed/lexical_stylistic_prompting/v2/earnings21_window_posthoc_blind"
 )
+# "context" mode: correct the [5:00, 15:00] window using the unprompted 0:00-5:00 transcript of
+# the same call as an in-prompt reference (self-contained — no metadata, no LLM-built profile).
+DEFAULT_CONTEXT_OUT_DIR = Path(
+    "data/processed/lexical_stylistic_prompting/v2/earnings21_window_posthoc_context"
+)
+DEFAULT_PROFILE_TRANSCRIPTS_DIR = Path(
+    "data/processed/lexical_stylistic_prompting/v2/profile_transcripts"
+)
+DEFAULT_PROFILE_TAG = 300  # profile-window length in seconds; filenames are <call_id>_<tag>.json
 # Sentence-grouped chunk size sent to the LLM. Larger chunks = fewer requests (KISSKI caps at
 # ~10/min, 200/hour, 400/day); a ~1,400-word window at 450 words is ~3 requests instead of ~7.
 CHUNK_TARGET_WORDS = 450
@@ -100,28 +124,34 @@ def chunk_text(text: str, target_words: int = CHUNK_TARGET_WORDS) -> list[str]:
 
 # ── correction ────────────────────────────────────────────────────────────────
 
-def _correct_chunk(client: OpenAI, model: str, chunk: str) -> str:
+def _correct_chunk(client: OpenAI, model: str, chunk: str,
+                   reference: str | None = None) -> str:
     words = len(chunk.split())
     # allow headroom over the input length so a correct-length output never truncates
     max_tokens = max(256, int(words * 2) + 64)
-    raw = _llm_call(
-        client,
-        model,
-        POSTHOC_CORRECT_SYSTEM,
-        POSTHOC_CORRECT_USER.format(chunk=chunk),
-        max_tokens=max_tokens,
-    )
+    if reference:
+        system = POSTHOC_CONTEXT_SYSTEM
+        user = POSTHOC_CONTEXT_USER.format(reference=reference, chunk=chunk)
+    else:
+        system = POSTHOC_CORRECT_SYSTEM
+        user = POSTHOC_CORRECT_USER.format(chunk=chunk)
+    raw = _llm_call(client, model, system, user, max_tokens=max_tokens)
     return raw.strip().strip("\"'").strip()
 
 
 def correct_hypothesis(client: OpenAI, model: str, hypothesis: str,
-                       chunk_words: int = CHUNK_TARGET_WORDS, label: str = "") -> str:
-    """Correct a full window hypothesis chunk-by-chunk and reassemble it."""
+                       chunk_words: int = CHUNK_TARGET_WORDS, label: str = "",
+                       reference: str | None = None) -> str:
+    """Correct a full window hypothesis chunk-by-chunk and reassemble it.
+
+    When ``reference`` is given (the 0:00-5:00 transcript of the same call), each chunk is
+    corrected with that preamble as an in-prompt hint; otherwise correction is blind.
+    """
     chunks = chunk_text(hypothesis, chunk_words)
     corrected: list[str] = []
     for i, chunk in enumerate(chunks, 1):
         logger.info(f"    {label} chunk {i}/{len(chunks)} ({len(chunk.split())} words) → KISSKI ...")
-        corrected.append(_correct_chunk(client, model, chunk))
+        corrected.append(_correct_chunk(client, model, chunk, reference))
     return " ".join(part for part in corrected if part).strip()
 
 
@@ -133,8 +163,10 @@ def _edit_ratio(raw: str, corrected: str) -> float:
 
 
 def process_call(client: OpenAI, model: str, call_id: str, raw: str,
-                 max_edit_ratio: float, chunk_words: int = CHUNK_TARGET_WORDS) -> PosthocRow:
-    corrected = correct_hypothesis(client, model, raw, chunk_words, label=call_id)
+                 max_edit_ratio: float, chunk_words: int = CHUNK_TARGET_WORDS,
+                 reference: str | None = None) -> PosthocRow:
+    corrected = correct_hypothesis(client, model, raw, chunk_words, label=call_id,
+                                   reference=reference)
     ratio = _edit_ratio(raw, corrected)
     guard = ratio > max_edit_ratio or not corrected.strip()
     if guard:
@@ -170,11 +202,30 @@ def _merge_all(out_dir: Path) -> Path:
     return merged
 
 
+def _load_reference(ref_dir: Path, call_id: str, tag: int) -> str:
+    """Load the unprompted 0:00-5:00 transcript used as an in-prompt correction hint."""
+    path = ref_dir / f"{call_id}_{tag}.json"
+    if not path.exists():
+        logger.warning(f"{call_id}: no reference transcript at {path} — correcting this call blind")
+        return ""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return str(data.get("transcript", "")).strip()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Post-hoc LLM correction of v2 baseline hypotheses")
     parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE,
                         help="baseline_all.csv with call_id + hypothesis columns")
-    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--out-dir", type=Path, default=None,
+                        help="output dir (default: posthoc_blind, or posthoc_context in context mode)")
+    parser.add_argument("--use-context", action="store_true",
+                        help="correct each call using its unprompted 0:00-5:00 transcript as an "
+                             "in-prompt reference (self-contained; no metadata/profile)")
+    parser.add_argument("--reference-transcripts-dir", type=Path,
+                        default=DEFAULT_PROFILE_TRANSCRIPTS_DIR,
+                        help="dir of 0:00-5:00 transcripts (<call_id>_<tag>.json) for --use-context")
+    parser.add_argument("--profile-tag", type=int, default=DEFAULT_PROFILE_TAG,
+                        help="reference-transcript filename tag (profile-window seconds)")
     parser.add_argument("--model", default=DEFAULT_LLM_MODEL)
     parser.add_argument("--max-edit-ratio", type=float, default=DEFAULT_MAX_EDIT_RATIO,
                         help="revert to the raw hypothesis if the correction changed more than this")
@@ -185,7 +236,10 @@ def main() -> None:
                         help="Skip calls that already have a posthoc_<id>.csv")
     args = parser.parse_args()
 
-    args.out_dir.mkdir(parents=True, exist_ok=True)
+    out_dir = args.out_dir or (DEFAULT_CONTEXT_OUT_DIR if args.use_context else DEFAULT_OUT_DIR)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    mode = "context (0:00-5:00 reference)" if args.use_context else "blind"
+    logger.info(f"Post-hoc correction mode: {mode} → {out_dir}")
     df = pd.read_csv(args.baseline)
     df["call_id"] = df["call_id"].astype(str)
     if args.call_id:
@@ -200,23 +254,30 @@ def main() -> None:
 
     for idx, (_, r) in enumerate(df.iterrows(), 1):
         call_id = str(r["call_id"])
-        out_path = args.out_dir / f"posthoc_{call_id}.csv"
+        out_path = out_dir / f"posthoc_{call_id}.csv"
         if args.skip_existing and out_path.exists():
             logger.info(f"[{idx}/{total}] {call_id}: skipping (cached)")
             skipped += 1
             continue
         raw = str(r["hypothesis"]) if pd.notna(r["hypothesis"]) else ""
+        reference = (
+            _load_reference(args.reference_transcripts_dir, call_id, args.profile_tag)
+            if args.use_context else None
+        )
         n_chunks = len(chunk_text(raw, args.chunk_words))
-        logger.info(f"[{idx}/{total}] {call_id}: correcting {len(raw.split())} words in {n_chunks} chunks ...")
-        row = process_call(client, args.model, call_id, raw, args.max_edit_ratio, args.chunk_words)
-        _write_row(args.out_dir, row)
+        ref_note = f", ref={len(reference.split())}w" if reference else ""
+        logger.info(f"[{idx}/{total}] {call_id}: correcting {len(raw.split())} words "
+                    f"in {n_chunks} chunks{ref_note} ...")
+        row = process_call(client, args.model, call_id, raw, args.max_edit_ratio,
+                           args.chunk_words, reference=reference)
+        _write_row(out_dir, row)
         corrected += 1
         reverted += int(row.guard_applied)
         logger.success(f"[{idx}/{total}] {call_id}: done — edit_ratio={row.edit_ratio} "
                        f"guard={row.guard_applied} ({row.raw_words}→{row.corrected_words} words)")
 
     logger.success(f"Finished — corrected {corrected} (reverted {reverted}), skipped {skipped} / {total}")
-    _merge_all(args.out_dir)
+    _merge_all(out_dir)
 
 
 if __name__ == "__main__":

--- a/src/lexical_stylistic_prompting/pipeline/earnings21_posthoc_correct.py
+++ b/src/lexical_stylistic_prompting/pipeline/earnings21_posthoc_correct.py
@@ -1,0 +1,223 @@
+"""
+Post-hoc LLM correction of the v2 baseline ASR hypotheses (RQ2 extension).
+
+Prompting Whisper via ``initial_prompt`` hurt WER (see the v2 metadata_only result). This
+module tries the opposite lever: leave decoding alone and instead have an LLM fix recognition
+errors in the *raw* baseline transcript of the [5:00, 15:00] evaluation window, then score the
+corrected text against the same hand-annotated golden references.
+
+Runs locally (KISSKI LLM, like profile building — no cluster). Reads ``baseline_all.csv`` and
+writes ``<out-dir>/prompted_all.csv`` (plus per-call ``posthoc_<id>.csv``) in the exact shape
+``earnings21_window_score.py`` expects, so scoring needs no changes::
+
+    uv run -m src.lexical_stylistic_prompting.pipeline.earnings21_window_score \\
+        --annotations manual_annotation.csv --approach posthoc_blind
+
+Design (see arXiv 2409.09554 / 2307.04172):
+- Conservative / verbatim correction — the reference is verbatim .nlp text, and we only have a
+  single (1-best) hypothesis, the setup most prone to over-correction. The prompt forbids
+  rewriting; an edit-ratio guard reverts to the raw hypothesis if the LLM changed too much.
+- Sentence-boundary chunking (~200 words) keeps each LLM call short so verbatim discipline
+  holds and output length can't drift/truncate over a long span.
+
+Usage:
+    uv run -m src.lexical_stylistic_prompting.pipeline.earnings21_posthoc_correct \\
+        --baseline data/processed/lexical_stylistic_prompting/v2/earnings21_window_baseline/baseline_all.csv \\
+        --skip-existing
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import re
+from pathlib import Path
+
+import pandas as pd
+from loguru import logger
+from openai import OpenAI
+from pydantic import BaseModel
+
+from src.asr_adaptation.metrics.wer import compute_wer
+from src.lexical_stylistic_prompting.models.constants import DEFAULT_LLM_MODEL
+from src.lexical_stylistic_prompting.models.prompts import (
+    POSTHOC_CORRECT_SYSTEM,
+    POSTHOC_CORRECT_USER,
+)
+from src.lexical_stylistic_prompting.models.speaker_profile import _get_client, _llm_call
+
+DEFAULT_BASELINE = Path(
+    "data/processed/lexical_stylistic_prompting/v2/earnings21_window_baseline/baseline_all.csv"
+)
+DEFAULT_OUT_DIR = Path(
+    "data/processed/lexical_stylistic_prompting/v2/earnings21_window_posthoc_blind"
+)
+# Sentence-grouped chunk size sent to the LLM. Larger chunks = fewer requests (KISSKI caps at
+# ~10/min, 200/hour, 400/day); a ~1,400-word window at 450 words is ~3 requests instead of ~7.
+CHUNK_TARGET_WORDS = 450
+DEFAULT_MAX_EDIT_RATIO = 0.30  # revert to raw if the correction changed more than this fraction
+
+
+class PosthocRow(BaseModel):
+    call_id: str
+    model: str
+    raw_words: int
+    corrected_words: int
+    edit_ratio: float       # word-level change of the LLM output vs the raw hypothesis
+    guard_applied: bool     # True → over-correction guard tripped, hypothesis reverted to raw
+    hypothesis: str         # final (possibly reverted) text — what score.py reads
+    raw_hypothesis: str
+
+
+# ── chunking ──────────────────────────────────────────────────────────────────
+
+def _split_sentences(text: str) -> list[str]:
+    """Split on whitespace following sentence-terminal punctuation, keeping the punctuation."""
+    pieces = re.split(r"(?<=[.!?])\s+", text.strip())
+    return [p for p in pieces if p.strip()]
+
+
+def chunk_text(text: str, target_words: int = CHUNK_TARGET_WORDS) -> list[str]:
+    """Group whole sentences into chunks of ~target_words (never splitting a sentence)."""
+    sentences = _split_sentences(text)
+    if not sentences:
+        return [text.strip()] if text.strip() else []
+    chunks: list[str] = []
+    current: list[str] = []
+    count = 0
+    for sentence in sentences:
+        words = len(sentence.split())
+        if current and count + words > target_words:
+            chunks.append(" ".join(current))
+            current, count = [], 0
+        current.append(sentence)
+        count += words
+    if current:
+        chunks.append(" ".join(current))
+    return chunks
+
+
+# ── correction ────────────────────────────────────────────────────────────────
+
+def _correct_chunk(client: OpenAI, model: str, chunk: str) -> str:
+    words = len(chunk.split())
+    # allow headroom over the input length so a correct-length output never truncates
+    max_tokens = max(256, int(words * 2) + 64)
+    raw = _llm_call(
+        client,
+        model,
+        POSTHOC_CORRECT_SYSTEM,
+        POSTHOC_CORRECT_USER.format(chunk=chunk),
+        max_tokens=max_tokens,
+    )
+    return raw.strip().strip("\"'").strip()
+
+
+def correct_hypothesis(client: OpenAI, model: str, hypothesis: str,
+                       chunk_words: int = CHUNK_TARGET_WORDS, label: str = "") -> str:
+    """Correct a full window hypothesis chunk-by-chunk and reassemble it."""
+    chunks = chunk_text(hypothesis, chunk_words)
+    corrected: list[str] = []
+    for i, chunk in enumerate(chunks, 1):
+        logger.info(f"    {label} chunk {i}/{len(chunks)} ({len(chunk.split())} words) → KISSKI ...")
+        corrected.append(_correct_chunk(client, model, chunk))
+    return " ".join(part for part in corrected if part).strip()
+
+
+def _edit_ratio(raw: str, corrected: str) -> float:
+    """Word-level fraction of the raw hypothesis changed by the correction (normalized)."""
+    if not raw.strip():
+        return 0.0
+    return compute_wer([raw], [corrected])
+
+
+def process_call(client: OpenAI, model: str, call_id: str, raw: str,
+                 max_edit_ratio: float, chunk_words: int = CHUNK_TARGET_WORDS) -> PosthocRow:
+    corrected = correct_hypothesis(client, model, raw, chunk_words, label=call_id)
+    ratio = _edit_ratio(raw, corrected)
+    guard = ratio > max_edit_ratio or not corrected.strip()
+    if guard:
+        logger.warning(f"{call_id}: edit_ratio={ratio:.3f} > {max_edit_ratio} — reverting to raw")
+    final = raw if guard else corrected
+    return PosthocRow(
+        call_id=call_id,
+        model=model,
+        raw_words=len(raw.split()),
+        corrected_words=len(corrected.split()),
+        edit_ratio=round(ratio, 4),
+        guard_applied=guard,
+        hypothesis=final,
+        raw_hypothesis=raw,
+    )
+
+
+# ── io ────────────────────────────────────────────────────────────────────────
+
+def _write_row(out_dir: Path, row: PosthocRow) -> None:
+    out = out_dir / f"posthoc_{row.call_id}.csv"
+    with open(out, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(PosthocRow.model_fields))
+        writer.writeheader()
+        writer.writerow(row.model_dump())
+
+
+def _merge_all(out_dir: Path) -> Path:
+    files = sorted(glob.glob(str(out_dir / "posthoc_[0-9]*.csv")))
+    merged = out_dir / "prompted_all.csv"
+    pd.concat([pd.read_csv(f) for f in files]).to_csv(merged, index=False)
+    logger.info(f"Merged {len(files)} per-call files → {merged}")
+    return merged
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Post-hoc LLM correction of v2 baseline hypotheses")
+    parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE,
+                        help="baseline_all.csv with call_id + hypothesis columns")
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--model", default=DEFAULT_LLM_MODEL)
+    parser.add_argument("--max-edit-ratio", type=float, default=DEFAULT_MAX_EDIT_RATIO,
+                        help="revert to the raw hypothesis if the correction changed more than this")
+    parser.add_argument("--chunk-words", type=int, default=CHUNK_TARGET_WORDS,
+                        help="sentence-grouped chunk size sent to the LLM (larger = fewer requests)")
+    parser.add_argument("--call-id", default=None, help="Process a single call only")
+    parser.add_argument("--skip-existing", action="store_true",
+                        help="Skip calls that already have a posthoc_<id>.csv")
+    args = parser.parse_args()
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    df = pd.read_csv(args.baseline)
+    df["call_id"] = df["call_id"].astype(str)
+    if args.call_id:
+        df = df[df["call_id"] == args.call_id]
+        if df.empty:
+            logger.error(f"Call {args.call_id!r} not found in {args.baseline}")
+            return
+
+    client = _get_client()
+    corrected, skipped, reverted = 0, 0, 0
+    total = len(df)
+
+    for idx, (_, r) in enumerate(df.iterrows(), 1):
+        call_id = str(r["call_id"])
+        out_path = args.out_dir / f"posthoc_{call_id}.csv"
+        if args.skip_existing and out_path.exists():
+            logger.info(f"[{idx}/{total}] {call_id}: skipping (cached)")
+            skipped += 1
+            continue
+        raw = str(r["hypothesis"]) if pd.notna(r["hypothesis"]) else ""
+        n_chunks = len(chunk_text(raw, args.chunk_words))
+        logger.info(f"[{idx}/{total}] {call_id}: correcting {len(raw.split())} words in {n_chunks} chunks ...")
+        row = process_call(client, args.model, call_id, raw, args.max_edit_ratio, args.chunk_words)
+        _write_row(args.out_dir, row)
+        corrected += 1
+        reverted += int(row.guard_applied)
+        logger.success(f"[{idx}/{total}] {call_id}: done — edit_ratio={row.edit_ratio} "
+                       f"guard={row.guard_applied} ({row.raw_words}→{row.corrected_words} words)")
+
+    logger.success(f"Finished — corrected {corrected} (reverted {reverted}), skipped {skipped} / {total}")
+    _merge_all(args.out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lexical_stylistic_prompting/pipeline/earnings21_posthoc_correct.py
+++ b/src/lexical_stylistic_prompting/pipeline/earnings21_posthoc_correct.py
@@ -20,13 +20,20 @@ Design (see arXiv 2409.09554 / 2307.04172):
 - Sentence-boundary chunking (~200 words) keeps each LLM call short so verbatim discipline
   holds and output length can't drift/truncate over a long span.
 
-Two modes:
+Three modes:
 - blind (default): the LLM sees only the eval-window chunk (writes to earnings21_window_posthoc_blind).
 - context (--use-context): each chunk is corrected with the unprompted 0:00-5:00 transcript of the
   SAME call as an in-prompt reference — self-contained (no metadata, no LLM-built profile), the
   post-hoc counterpart of the transcript_only prompting method. Writes to
   earnings21_window_posthoc_context. The reference is raw ASR, so the prompt treats it as a hint
   only and forbids copying from it.
+- profile (--use-profile): each chunk is corrected with a curated, spell-corrected entity-list
+  profile of the SAME call as an AUTHORITATIVE reference — the post-hoc counterpart of injecting
+  that same profile into Whisper's initial_prompt (one profile, two injection points). Unlike
+  context, the prompt tells the model to trust the list and adopt its spellings. --profile-strategy
+  selects WHICH built profile (default transcript_metadata_knowledge; also metadata_only,
+  transcript_only, transcript_plus_knowledge, or any *_prose variant) and names the output dir
+  earnings21_window_posthoc_profile_<strategy>, so runs over different profiles never collide.
 
 Usage:
     # blind
@@ -34,8 +41,15 @@ Usage:
     # context (0:00-5:00 self-reference)
     uv run -m src.lexical_stylistic_prompting.pipeline.earnings21_posthoc_correct \\
         --use-context --skip-existing
+    # profile (default transcript_metadata_knowledge)
+    uv run -m src.lexical_stylistic_prompting.pipeline.earnings21_posthoc_correct \\
+        --use-profile --skip-existing
+    # profile — switch strategy with one flag
+    uv run -m src.lexical_stylistic_prompting.pipeline.earnings21_posthoc_correct \\
+        --use-profile --profile-strategy metadata_only --skip-existing
 
-Score either with earnings21_window_score.py --approach posthoc_blind / posthoc_context.
+Score with earnings21_window_score.py --approach posthoc_blind / posthoc_context /
+posthoc_profile_<strategy> (e.g. posthoc_profile_transcript_metadata_knowledge).
 """
 
 from __future__ import annotations
@@ -59,6 +73,8 @@ from src.lexical_stylistic_prompting.models.prompts import (
     POSTHOC_CONTEXT_USER,
     POSTHOC_CORRECT_SYSTEM,
     POSTHOC_CORRECT_USER,
+    POSTHOC_PROFILE_SYSTEM,
+    POSTHOC_PROFILE_USER,
 )
 from src.lexical_stylistic_prompting.models.speaker_profile import _get_client, _llm_call
 
@@ -76,6 +92,17 @@ DEFAULT_CONTEXT_OUT_DIR = Path(
 DEFAULT_PROFILE_TRANSCRIPTS_DIR = Path(
     "data/processed/lexical_stylistic_prompting/v2/profile_transcripts"
 )
+# "profile" mode: correct the [5:00, 15:00] window using a curated, spell-corrected entity-list
+# profile of the same call as an authoritative reference (the post-hoc counterpart of injecting
+# that same profile into Whisper's initial_prompt). WHICH profile is chosen by --profile-strategy:
+# each strategy is a subdir of PROFILES_ROOT, so switching transcript_metadata_knowledge →
+# metadata_only / transcript_only / transcript_plus_knowledge / any *_prose variant is one flag.
+# The chosen strategy also names the output dir (earnings21_window_posthoc_profile_<strategy>) so
+# runs over different profiles never overwrite one another.
+PROFILES_ROOT = Path("data/processed/lexical_stylistic_prompting/v2/profiles")
+DEFAULT_PROFILE_STRATEGY = "transcript_metadata_knowledge"
+# base under which profile mode writes earnings21_window_posthoc_profile_<strategy>/
+POSTHOC_OUT_ROOT = Path("data/processed/lexical_stylistic_prompting/v2")
 DEFAULT_PROFILE_TAG = 300  # profile-window length in seconds; filenames are <call_id>_<tag>.json
 # Sentence-grouped chunk size sent to the LLM. Larger chunks = fewer requests (KISSKI caps at
 # ~10/min, 200/hour, 400/day); a ~1,400-word window at 450 words is ~3 requests instead of ~7.
@@ -125,11 +152,14 @@ def chunk_text(text: str, target_words: int = CHUNK_TARGET_WORDS) -> list[str]:
 # ── correction ────────────────────────────────────────────────────────────────
 
 def _correct_chunk(client: OpenAI, model: str, chunk: str,
-                   reference: str | None = None) -> str:
+                   reference: str | None = None, profile: str | None = None) -> str:
     words = len(chunk.split())
     # allow headroom over the input length so a correct-length output never truncates
     max_tokens = max(256, int(words * 2) + 64)
-    if reference:
+    if profile:
+        system = POSTHOC_PROFILE_SYSTEM
+        user = POSTHOC_PROFILE_USER.format(profile=profile, chunk=chunk)
+    elif reference:
         system = POSTHOC_CONTEXT_SYSTEM
         user = POSTHOC_CONTEXT_USER.format(reference=reference, chunk=chunk)
     else:
@@ -141,17 +171,19 @@ def _correct_chunk(client: OpenAI, model: str, chunk: str,
 
 def correct_hypothesis(client: OpenAI, model: str, hypothesis: str,
                        chunk_words: int = CHUNK_TARGET_WORDS, label: str = "",
-                       reference: str | None = None) -> str:
+                       reference: str | None = None, profile: str | None = None) -> str:
     """Correct a full window hypothesis chunk-by-chunk and reassemble it.
 
-    When ``reference`` is given (the 0:00-5:00 transcript of the same call), each chunk is
-    corrected with that preamble as an in-prompt hint; otherwise correction is blind.
+    When ``profile`` is given (the curated transcript_metadata_knowledge entity list of the same
+    call), each chunk is corrected with that authoritative list as an in-prompt reference. Otherwise,
+    when ``reference`` is given (the raw 0:00-5:00 transcript of the same call), each chunk is
+    corrected with that preamble as a hint; otherwise correction is blind.
     """
     chunks = chunk_text(hypothesis, chunk_words)
     corrected: list[str] = []
     for i, chunk in enumerate(chunks, 1):
         logger.info(f"    {label} chunk {i}/{len(chunks)} ({len(chunk.split())} words) → KISSKI ...")
-        corrected.append(_correct_chunk(client, model, chunk, reference))
+        corrected.append(_correct_chunk(client, model, chunk, reference, profile))
     return " ".join(part for part in corrected if part).strip()
 
 
@@ -164,9 +196,9 @@ def _edit_ratio(raw: str, corrected: str) -> float:
 
 def process_call(client: OpenAI, model: str, call_id: str, raw: str,
                  max_edit_ratio: float, chunk_words: int = CHUNK_TARGET_WORDS,
-                 reference: str | None = None) -> PosthocRow:
+                 reference: str | None = None, profile: str | None = None) -> PosthocRow:
     corrected = correct_hypothesis(client, model, raw, chunk_words, label=call_id,
-                                   reference=reference)
+                                   reference=reference, profile=profile)
     ratio = _edit_ratio(raw, corrected)
     guard = ratio > max_edit_ratio or not corrected.strip()
     if guard:
@@ -212,20 +244,52 @@ def _load_reference(ref_dir: Path, call_id: str, tag: int) -> str:
     return str(data.get("transcript", "")).strip()
 
 
+def profiles_dir_for(root: Path, strategy: str) -> Path:
+    """Directory of per-call profile JSONs for a strategy (a subdir of the profiles root)."""
+    return root / strategy
+
+
+def profile_out_dir_for(strategy: str) -> Path:
+    """Output dir for a profile strategy — strategy-tagged so runs never collide."""
+    return POSTHOC_OUT_ROOT / f"earnings21_window_posthoc_profile_{strategy}"
+
+
+def _load_profile(profiles_dir: Path, call_id: str, tag: int) -> str:
+    """Load a curated entity-list profile (its ``prompt`` field) as an authoritative reference."""
+    path = profiles_dir / f"{call_id}_{tag}.json"
+    if not path.exists():
+        logger.warning(f"{call_id}: no profile at {path} — correcting this call blind")
+        return ""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return str(data.get("prompt", "")).strip()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Post-hoc LLM correction of v2 baseline hypotheses")
     parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE,
                         help="baseline_all.csv with call_id + hypothesis columns")
     parser.add_argument("--out-dir", type=Path, default=None,
-                        help="output dir (default: posthoc_blind, or posthoc_context in context mode)")
-    parser.add_argument("--use-context", action="store_true",
-                        help="correct each call using its unprompted 0:00-5:00 transcript as an "
-                             "in-prompt reference (self-contained; no metadata/profile)")
+                        help="output dir (default: posthoc_blind, or posthoc_context / posthoc_profile "
+                             "in the respective modes)")
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument("--use-context", action="store_true",
+                            help="correct each call using its unprompted 0:00-5:00 transcript as an "
+                                 "in-prompt reference (self-contained; no metadata/profile)")
+    mode_group.add_argument("--use-profile", action="store_true",
+                            help="correct each call using its curated transcript_metadata_knowledge "
+                                 "entity list as an authoritative in-prompt reference")
     parser.add_argument("--reference-transcripts-dir", type=Path,
                         default=DEFAULT_PROFILE_TRANSCRIPTS_DIR,
                         help="dir of 0:00-5:00 transcripts (<call_id>_<tag>.json) for --use-context")
+    parser.add_argument("--profile-strategy", default=DEFAULT_PROFILE_STRATEGY,
+                        help="which built profile to inject in --use-profile mode: a subdir of "
+                             f"{PROFILES_ROOT} (e.g. metadata_only, transcript_only, "
+                             "transcript_plus_knowledge, transcript_metadata_knowledge, or any "
+                             "*_prose variant). Also names the output dir.")
+    parser.add_argument("--profiles-root", type=Path, default=PROFILES_ROOT,
+                        help="root dir holding the per-strategy profile subdirs")
     parser.add_argument("--profile-tag", type=int, default=DEFAULT_PROFILE_TAG,
-                        help="reference-transcript filename tag (profile-window seconds)")
+                        help="reference/profile filename tag (profile-window seconds)")
     parser.add_argument("--model", default=DEFAULT_LLM_MODEL)
     parser.add_argument("--max-edit-ratio", type=float, default=DEFAULT_MAX_EDIT_RATIO,
                         help="revert to the raw hypothesis if the correction changed more than this")
@@ -236,9 +300,24 @@ def main() -> None:
                         help="Skip calls that already have a posthoc_<id>.csv")
     args = parser.parse_args()
 
-    out_dir = args.out_dir or (DEFAULT_CONTEXT_OUT_DIR if args.use_context else DEFAULT_OUT_DIR)
+    profiles_dir = profiles_dir_for(args.profiles_root, args.profile_strategy)
+    if args.use_profile and not profiles_dir.is_dir():
+        available = sorted(p.name for p in args.profiles_root.iterdir() if p.is_dir())
+        logger.error(f"--profile-strategy {args.profile_strategy!r} not found at {profiles_dir}. "
+                     f"Available: {', '.join(available) or '(none)'}")
+        return
+
+    out_dir = args.out_dir or (
+        profile_out_dir_for(args.profile_strategy) if args.use_profile
+        else DEFAULT_CONTEXT_OUT_DIR if args.use_context
+        else DEFAULT_OUT_DIR
+    )
     out_dir.mkdir(parents=True, exist_ok=True)
-    mode = "context (0:00-5:00 reference)" if args.use_context else "blind"
+    mode = (
+        f"profile ({args.profile_strategy} entity list)" if args.use_profile
+        else "context (0:00-5:00 reference)" if args.use_context
+        else "blind"
+    )
     logger.info(f"Post-hoc correction mode: {mode} → {out_dir}")
     df = pd.read_csv(args.baseline)
     df["call_id"] = df["call_id"].astype(str)
@@ -264,12 +343,17 @@ def main() -> None:
             _load_reference(args.reference_transcripts_dir, call_id, args.profile_tag)
             if args.use_context else None
         )
+        profile = (
+            _load_profile(profiles_dir, call_id, args.profile_tag)
+            if args.use_profile else None
+        )
         n_chunks = len(chunk_text(raw, args.chunk_words))
-        ref_note = f", ref={len(reference.split())}w" if reference else ""
+        hint = profile or reference
+        ref_note = f", {'profile' if profile else 'ref'}={len(hint.split())}w" if hint else ""
         logger.info(f"[{idx}/{total}] {call_id}: correcting {len(raw.split())} words "
                     f"in {n_chunks} chunks{ref_note} ...")
         row = process_call(client, args.model, call_id, raw, args.max_edit_ratio,
-                           args.chunk_words, reference=reference)
+                           args.chunk_words, reference=reference, profile=profile)
         _write_row(out_dir, row)
         corrected += 1
         reverted += int(row.guard_applied)


### PR DESCRIPTION
Adds the post-hoc approach with 3 different methods:
- blind post-hoc
- transcript post-hoc
- profile post-hoc (which allows the usage of the previously defined profiles when correcting with the LLM)